### PR TITLE
Make Token Validation optional and configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
-| 'token_validation' | bool | Whether to validate the token or not. | `true` |
+| `token_validation` | bool | Whether to validate the token or not. | `true` |
 | `aes_key` | `string` | A base64 encoded AES-256 Key | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q` |
 | `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` |
 | `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
+| 'token_validation' | bool | Whether to validate the token or not. | `true` |
 | `aes_key` | `string` | A base64 encoded AES-256 Key | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q` |
 | `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` |
 | `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` |

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -40,6 +40,7 @@ static_resources:
 
                           cookie_name: "oidcSession"
                           cookie_duration: 86400
+                          token_validation: true
                           aes_key: "SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q"
 
                           authority: "auth.k8s.wwu.de"

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,8 @@ pub struct PluginConfiguration {
     pub cookie_name: String,
     /// The cookie duration in seconds
     pub cookie_duration: u64,
+    /// Option to skip Token Validation
+    pub token_validation: bool,
     /// AES Key
     pub aes_key: String,
 


### PR DESCRIPTION
Depending on the key size of the signing JWK, the token validation can take approx. 20 ms (8192-key). Wasm has poor crypto performance and takes significantly longer when comparing to native executables.

Also see [Wasi Crypto Project](https://github.com/WebAssembly/wasi-crypto)