### PR TITLE
Forward Access Token and/or ID-Token to backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "wasm-oidc-plugin"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["WWU Cloud Developer <cloud@uni-muenster.de>, Anton Engelhardt <antoncengelhardt@icloud.com>"]
 description = "WASM OIDC Envoy Plugin"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | ---- | ---- | ----------- | ------- |
 | `config_endpoint` | `string` | The open id configuration endpoint. | `https://accounts.google.com/.well-known/openid-configuration` |
 | `reload_interval_in_hours` | `u64` | The interval in hours, after which the OIDC configuration is reloaded. | `24` |
-| `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filtrr. | `["localhost:10000"]` |
+| `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filter. | `["localhost:10000"]` |
 | `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` |
 | `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
 | `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` |
@@ -82,7 +82,7 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
 | `token_validation` | bool | Whether to validate the token or not. | `true` |
-| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32 | tr -d '='` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q` |
+| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q=` |
 | `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` |
 | `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` |
 | `client_id` | `string` | The client ID, for getting and exchanging the code. | `wasm-oidc-plugin` |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer` |
 | `forward_id_token` | `bool` | Whether to forward the id token to the upstream service or not. | `true` |
 | `id_token_header_name` | `string` | The name of the header, that is used to forward the id token, if empty "X-Id-Token" is used. | `X-Id-Token` |
+| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer` |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
 | `token_validation` | bool | Whether to validate the token or not. | `true` |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filtrr. | `["localhost:10000"]` |
 | `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` |
 | `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
+| `forward_access_token` | `bool` | Whether to forward the access token to the upstream service or not. | `true` |
+| `access_token_header_name` | `string` | The name of the header, that is used to forward the access token, if empty "Authorization" is used. | `X-Access-Token` |
+| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer` |
+| `forward_id_token` | `bool` | Whether to forward the id token to the upstream service or not. | `true` |
+| `id_token_header_name` | `string` | The name of the header, that is used to forward the id token, if empty "X-Id-Token" is used. | `X-Id-Token` |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
 | `token_validation` | bool | Whether to validate the token or not. | `true` |

--- a/README.md
+++ b/README.md
@@ -75,12 +75,10 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filtrr. | `["localhost:10000"]` |
 | `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` |
 | `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
-| `forward_access_token` | `bool` | Whether to forward the access token to the upstream service or not. | `true` |
-| `access_token_header_name` | `string` | The name of the header, that is used to forward the access token, if empty "Authorization" is used. | `X-Access-Token` |
-| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer` |
-| `forward_id_token` | `bool` | Whether to forward the id token to the upstream service or not. | `true` |
-| `id_token_header_name` | `string` | The name of the header, that is used to forward the id token, if empty "X-Id-Token" is used. | `X-Id-Token` |
-| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer` |
+| `access_token_header_name` | `string` | The name of the header, that is used to forward the access token, if empty the header is not forwarded | `X-Access-Token` |
+| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` |
+| `id_token_header_name` | `string` | The name of the header, that is used to forward the id token, if empty the header is not forwarded. | `X-Id-Token` |
+| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
 | `token_validation` | bool | Whether to validate the token or not. | `true` |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
 | `token_validation` | bool | Whether to validate the token or not. | `true` |
-| `aes_key` | `string` | A base64 encoded AES-256 Key | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q` |
+| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32 | tr -d '='` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q` |
 | `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` |
 | `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` |
 | `client_id` | `string` | The client ID, for getting and exchanging the code. | `wasm-oidc-plugin` |
@@ -93,7 +93,9 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 
 With these configuration options, the plugin starts and loads more information itself such as the OIDC providers public keys, issuer, etc.
 
-For that a state is used, which determines, what to load next. The following states are possbile and depending on the outcome, the state is changed or not:
+### States
+
+For that a state is used, which determines, what to load next. The following states are possible and depending on the outcome, the state is changed or not:
 
 | State | Description |
 | ---- | ----------- |
@@ -108,7 +110,7 @@ When a new request arrives, the root context creates a new http context with the
 
 Then, one of the following cases is handled:
 
-1. The filter is not configured yet and still loading the configuration. The request is paused and queued until the configuration is loaded. Then, then, the RootContext resumes the request and the Request is redirected in order to create a new context.
+1. The filter is not configured yet and still loading the configuration. The request is paused and queued until the configuration is loaded. Then, the RootContext resumes the request and the Request is redirected in order to create a new context.
 2. The request has the code parameter in the URL query. This means that the user has been redirected back from the `authorization_endpoint` after successful authentication. The plugin exchanges the code for a token using the `token_endpoint` and stores the token in the session. Then, the user is redirected back to the original request.
 3. The request has a valid session cookie. The plugin decoded, decrypts and then validates the cookie and passes the request depending on the outcome of the validation of the token.
 4. The request has no valid session cookie. The plugin redirects the user to the `authorization_endpoint` to authenticate. Once, the user returns, the second case is handled.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ The plugin is configured via the `envoy.yaml` file. The following configuration 
 | `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filtrr. | `["localhost:10000"]` |
 | `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` |
 | `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
-| `access_token_header_name` | `string` | The name of the header, that is used to forward the access token, if empty the header is not forwarded | `X-Access-Token` |
+| `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` |
 | `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` |
-| `id_token_header_name` | `string` | The name of the header, that is used to forward the id token, if empty the header is not forwarded. | `X-Id-Token` |
+| `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` |
 | `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -32,27 +32,25 @@ static_resources:
                         "@type": "type.googleapis.com/google.protobuf.StringValue"
                         value: |
                           config_endpoint: "https://auth.k8s.wwu.de/.well-known/openid-configuration"
-                          reload_interval_in_h: 1
+                          reload_interval_in_h: 1 # in hours
 
-                          exclude_hosts: []
-                          exclude_paths: []
-                          exclude_urls: []
+                          exclude_hosts: [] # or ["httpbin.org"]
+                          exclude_paths: [] # or ["/anything"]
+                          exclude_urls: [] # or ["http://httpbin.org/anything"]
 
-                          forward_access_token: true
-                          access_token_header_name: "Authorization"
+                          access_token_header_name: # or "Authorization"
                           access_token_header_prefix: "Bearer "
-                          forward_id_token: true
-                          id_token_header_name: "X-Id-Token"
+                          id_token_header_name: # or "X-Id-Token"
                           id_token_header_prefix: "Bearer "
 
                           cookie_name: "oidcSession"
-                          cookie_duration: 86400
-                          token_validation: true
+                          cookie_duration: 86400 # in seconds
+                          token_validation: true # or false
                           aes_key: "SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q"
 
-                          authority: "auth.k8s.wwu.de"
-                          redirect_uri: "http://localhost:10000/oidc/callback"
-                          client_id: "wasm-oidc-plugin"
+                          authority: "auth.k8s.wwu.de" # FQDN of the OIDC provider
+                          redirect_uri: "http://localhost:10000/oidc/callback" # redirect uri that is registered with the OIDC provider
+                          client_id: "wasm-oidc-plugin" # client id that is registered with the OIDC provider
                           scope: "openid profile email"
                           claims: "{\"id_token\":{\"groups\":null,\"username\":null}}"
 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -43,6 +43,7 @@ static_resources:
                           access_token_header_prefix: "Bearer "
                           forward_id_token: true
                           id_token_header_name: "X-Id-Token"
+                          id_token_header_prefix: "Bearer "
 
                           cookie_name: "oidcSession"
                           cookie_duration: 86400

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -38,6 +38,12 @@ static_resources:
                           exclude_paths: []
                           exclude_urls: []
 
+                          forward_access_token: true
+                          access_token_header_name: "Authorization"
+                          access_token_header_prefix: "Bearer "
+                          forward_id_token: true
+                          id_token_header_name: "X-Id-Token"
+
                           cookie_name: "oidcSession"
                           cookie_duration: 86400
                           token_validation: true

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -46,7 +46,7 @@ static_resources:
                           cookie_name: "oidcSession"
                           cookie_duration: 86400 # in seconds
                           token_validation: true # or false
-                          aes_key: "SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q"
+                          aes_key: "WnIU7c7OJp90eRobUfz9G18VH8JbdNdwbEyBAr+85xo="
 
                           authority: "auth.k8s.wwu.de" # FQDN of the OIDC provider
                           redirect_uri: "http://localhost:10000/oidc/callback" # redirect uri that is registered with the OIDC provider

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,9 @@ pub struct PluginConfiguration {
     /// The header name that will be used for the id token
     /// If the header name is empty, the id token will be forwarded in X-Id-Token header
     pub id_token_header_name: String,
+    /// Prefix for the id token header
+    /// If the prefix is empty, the id token will be forwarded without a prefix
+    pub id_token_header_prefix: String,
 
     // Cookie settings
     /// The cookie name that will be used for the session cookie

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,22 +50,19 @@ pub struct PluginConfiguration {
     pub exclude_urls: Vec<Regex>,
 
     // Header forwarding settings
-    /// Forward the access token in a header
-    pub forward_access_token: bool,
     /// The header name that will be used for the access token
-    /// If the header name is empty, the access token will be forwarded in the authorization header
-    pub access_token_header_name: String,
+    /// If the header name is empty, the access token will not be forwarded
+    pub access_token_header_name: Option<String>,
     /// Prefix for the access token header
     /// If the prefix is empty, the access token will be forwarded without a prefix
-    pub access_token_header_prefix: String,
-    /// Forward the id token in a header
-    pub forward_id_token: bool,
+    pub access_token_header_prefix: Option<String>,
+
     /// The header name that will be used for the id token
-    /// If the header name is empty, the id token will be forwarded in X-Id-Token header
-    pub id_token_header_name: String,
+    /// If the header name is empty, the id token will not be forwarded
+    pub id_token_header_name: Option<String>,
     /// Prefix for the id token header
     /// If the prefix is empty, the id token will be forwarded without a prefix
-    pub id_token_header_prefix: String,
+    pub id_token_header_prefix: Option<String>,
 
     // Cookie settings
     /// The cookie name that will be used for the session cookie

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,21 @@ pub struct PluginConfiguration {
     #[serde(with = "serde_regex")]
     pub exclude_urls: Vec<Regex>,
 
+    // Header forwarding settings
+    /// Forward the access token in a header
+    pub forward_access_token: bool,
+    /// The header name that will be used for the access token
+    /// If the header name is empty, the access token will be forwarded in the authorization header
+    pub access_token_header_name: String,
+    /// Prefix for the access token header
+    /// If the prefix is empty, the access token will be forwarded without a prefix
+    pub access_token_header_prefix: String,
+    /// Forward the id token in a header
+    pub forward_id_token: bool,
+    /// The header name that will be used for the id token
+    /// If the header name is empty, the id token will be forwarded in X-Id-Token header
+    pub id_token_header_name: String,
+
     // Cookie settings
     /// The cookie name that will be used for the session cookie
     pub cookie_name: String,

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -29,11 +29,23 @@ pub struct AuthorizationState {
     pub id_token: String,
 }
 
+/// Struct that holds the encoded cookie and the encoded nonce as well as the access token and the id token
+pub struct EncodedCookies {
+    /// Encoded cookie
+    pub encoded_cookie: String,
+    /// Encoded nonce
+    pub encoded_nonce: String,
+    /// Access token
+    pub access_token: String,
+    /// ID token
+    pub id_token: String,
+}
+
 /// Implementation of the AuthorizationState struct
 impl AuthorizationState {
 
     /// Create a new encoded cookie from the response coming from the Token Endpoint
-    pub fn create_cookie_from_response(mut cipher: Aes256Gcm, res: &[u8]) -> Result<Vec<String>, String> {
+    pub fn create_cookie_from_response(mut cipher: Aes256Gcm, res: &[u8]) -> Result<EncodedCookies, String> {
 
         // Format the response into a slice and parse it in a struct
         match serde_json::from_slice::<AuthorizationState>(&res) {
@@ -51,7 +63,12 @@ impl AuthorizationState {
                 // Encode cookie
                 let encoded_cookie = base64engine.encode(encrypted_cookie.as_slice());
 
-                Ok(vec![encoded_cookie, encoded_nonce, state.access_token, state.id_token])
+                Ok(EncodedCookies {
+                    encoded_cookie,
+                    encoded_nonce,
+                    access_token: state.access_token,
+                    id_token: state.id_token,
+                })
             },
             // If the cookie cannot be parsed into a struct, return an error
             Err(e) => {

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -51,7 +51,7 @@ impl AuthorizationState {
                 // Encode cookie
                 let encoded_cookie = base64engine.encode(encrypted_cookie.as_slice());
 
-                Ok(vec![encoded_cookie, encoded_nonce])
+                Ok(vec![encoded_cookie, encoded_nonce, state.access_token, state.id_token])
             },
             // If the cookie cannot be parsed into a struct, return an error
             Err(e) => {
@@ -104,7 +104,7 @@ impl AuthorizationState {
             },
             // If the cookie cannot be parsed into a struct, return an error
             Err(e) => {
-                warn!("The cookie didnt match the expected format: {}", e);
+                warn!("The cookie didn't match the expected format: {}", e);
                 return Err(e.to_string())
             }
         }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use url::Url;
 
 // base64
-use base64::{engine::general_purpose::STANDARD_NO_PAD as base64engine, Engine as _};
+use base64::{engine::general_purpose::STANDARD as base64engine, Engine as _};
 
 // duration
 use std::time::Duration;

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -156,7 +156,7 @@ impl RootContext for OidcDiscovery {
 
     /// Creates the http context with the information from the open_id_config and the plugin configuration.
     /// This is called whenever a new http context is created by the proxy.
-    /// When the plugin is not yet ready, the http context is created in Unconfigured state and the
+    /// When the plugin is not yet ready, the http context is created in `Unconfigured` state and the
     /// context id is added to the waiting queue to be processed later.
     fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
 
@@ -179,7 +179,7 @@ impl RootContext for OidcDiscovery {
                 }));
             },
 
-            // If the plugin is not ready, return the http context in Unconfigured state and add the
+            // If the plugin is not ready, return the http context in `Unconfigured` state and add the
             // context id to the waiting queue.
             _ => {
                 warn!("Root context is not ready yet. Queueing http context.");
@@ -187,7 +187,7 @@ impl RootContext for OidcDiscovery {
                 // Add the context id to the waiting queue.
                 self.waiting.lock().unwrap().push(context_id);
 
-                // Return the http context in Unconfigured state.
+                // Return the http context in `Unconfigured` state.
                 return Some(Box::new(PauseRequests{
                     original_path: None,
                 }));
@@ -223,7 +223,7 @@ impl RootContext for OidcDiscovery {
                 self.set_tick_period(Duration::from_millis(250));
 
                 // Make call to openid configuration endpoint
-                // The reponse is handled in `on_http_call_response`.
+                // The response is handled in `on_http_call_response`.
                 match self.dispatch_http_call(
                     "oidc",
                     vec![
@@ -253,7 +253,7 @@ impl RootContext for OidcDiscovery {
             }  => {
 
                 // Make call to jwks endpoint and load public key
-                // The reponse is handled in `on_http_call_response`.
+                // The response is handled in `on_http_call_response`.
                 match self.dispatch_http_call(
                     "oidc",
                     vec![
@@ -291,14 +291,14 @@ impl RootContext for OidcDiscovery {
     }
 
     /// This is one of those functions that need to be there for some reason but we are
-    /// not sure why. It just doesnt work without it.
+    /// not sure why. It just doesn't work without it.
     fn get_type(&self) -> Option<proxy_wasm::types::ContextType> {
         Some(ContextType::HttpContext)
     }
 }
 
 /// The context is used to process the response from the OIDC config endpoint and the jwks endpoint.
-/// It also utilised the state enum to determine what to do with the response.
+/// It also utilized the state enum to determine what to do with the response.
 /// 1. If the state is `Uninitialized`, the plugin is not initialized and the response is ignored.
 /// 2. If the state is `LoadingConfig`, the open id configuration is expected.
 /// 3. If the state is `LoadingJwks`, the jwks endpoint is expected.
@@ -418,7 +418,7 @@ impl Context for OidcDiscovery {
                     }
                     Err(e) =>  {
                         warn!("error parsing jwks body: {:?}", e);
-                        // Stay in the same state as the response couldnt be parsed.
+                        // Stay in the same state as the response couldn't be parsed.
                         OidcRootState::LoadingJwks {
                             plugin_config: plugin_config.clone(),
                             auth_endpoint: auth_endpoint.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,25 +174,29 @@ impl HttpContext for ConfiguredOidc {
             match self.validate_cookie(cookie, nonce) {
                 Ok(auth_state) => {
                     // Forward access token in header, if configured
-                    if self.plugin_config.access_token_header_name.is_some() {
+                    if let Some(header_name) = &self.plugin_config.access_token_header_name {
                         // Get access token
                         let access_token = &auth_state.access_token;
+                        // Forward access token in header
                         self.add_http_request_header(
-                            self.plugin_config.access_token_header_name.as_ref().unwrap(),
+                            &header_name,
                             format!("{}{}",
-                                self.plugin_config.access_token_header_prefix.as_ref().unwrap(), access_token
+                                self.plugin_config.access_token_header_prefix.as_ref().unwrap(),
+                                access_token
                         ).as_str());
                     }
+
                     // Forward id token in header, if configured
-                    if self.plugin_config.id_token_header_name.is_some() {
+                    if let Some(header_name) = &self.plugin_config.id_token_header_name {
                         // Get id token
                         let id_token = &auth_state.id_token;
                         // Forward id token in header
                         self.add_http_request_header(
-                            self.plugin_config.id_token_header_name.as_ref().unwrap(),
+                            &header_name,
                             format!("{}{}",
                                 self.plugin_config.id_token_header_prefix.as_ref().unwrap(),
-                                id_token).as_str());
+                                id_token
+                        ).as_str());
                     }
 
                     // Allow request to pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,11 @@ impl HttpContext for ConfiguredOidc {
                             true => "X-Id-Token",
                             false => &self.plugin_config.id_token_header_name,
                         };
-                        self.add_http_request_header(id_token_header_name, id_token);
+                        let id_token_header_prefix = match self.plugin_config.id_token_header_prefix.is_empty() {
+                            true => "",
+                            false => &self.plugin_config.id_token_header_prefix,
+                        };
+                        self.add_http_request_header(id_token_header_name, format!("{}{}", id_token_header_prefix, id_token).as_str());
                     }
 
                     // Allow request to pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,35 +174,25 @@ impl HttpContext for ConfiguredOidc {
             match self.validate_cookie(cookie, nonce) {
                 Ok(auth_state) => {
                     // Forward access token in header, if configured
-                    if self.plugin_config.forward_access_token {
+                    if self.plugin_config.access_token_header_name.is_some() {
                         // Get access token
                         let access_token = &auth_state.access_token;
-                        // Forward access token in header
-                        let access_token_header_name = match self.plugin_config.access_token_header_name.is_empty() {
-                            true => "Authorization",
-                            false => &self.plugin_config.access_token_header_name,
-                        };
-                        // Forward access token with prefix
-                        let access_token_header_prefix = match self.plugin_config.access_token_header_prefix.is_empty() {
-                            true => "",
-                            false => &self.plugin_config.access_token_header_prefix,
-                        };
-                        self.add_http_request_header(access_token_header_name, format!("{}{}", access_token_header_prefix, access_token).as_str());
+                        self.add_http_request_header(
+                            self.plugin_config.access_token_header_name.as_ref().unwrap(),
+                            format!("{}{}",
+                                self.plugin_config.access_token_header_prefix.as_ref().unwrap(), access_token
+                        ).as_str());
                     }
                     // Forward id token in header, if configured
-                    if self.plugin_config.forward_id_token {
+                    if self.plugin_config.id_token_header_name.is_some() {
                         // Get id token
                         let id_token = &auth_state.id_token;
                         // Forward id token in header
-                        let id_token_header_name = match self.plugin_config.id_token_header_name.is_empty() {
-                            true => "X-Id-Token",
-                            false => &self.plugin_config.id_token_header_name,
-                        };
-                        let id_token_header_prefix = match self.plugin_config.id_token_header_prefix.is_empty() {
-                            true => "",
-                            false => &self.plugin_config.id_token_header_prefix,
-                        };
-                        self.add_http_request_header(id_token_header_name, format!("{}{}", id_token_header_prefix, id_token).as_str());
+                        self.add_http_request_header(
+                            self.plugin_config.id_token_header_name.as_ref().unwrap(),
+                            format!("{}{}",
+                                self.plugin_config.id_token_header_prefix.as_ref().unwrap(),
+                                id_token).as_str());
                     }
 
                     // Allow request to pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,8 +464,8 @@ impl ConfiguredOidc {
                 match cookie::AuthorizationState::create_cookie_from_response(self.cipher.clone(), body.as_slice()) {
                     Ok(res) => {
 
-                        let auth_cookie = res.first().unwrap().to_string();
-                        let nonce = res.get(1).unwrap().to_string();
+                        let auth_cookie = res.encoded_cookie;
+                        let nonce = res.encoded_nonce;
 
                         debug!("Cookie: {:?}", &auth_cookie);
                         debug!("Nonce: {:?}", &nonce);

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -13,6 +13,7 @@ use jwt_simple::{self, prelude::{RSAPublicKeyLike, VerificationOptions, JWTClaim
 /// [OpenID Connect Discovery Response](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
 #[derive(Deserialize, Debug)]
 pub struct OidcDiscoveryResponse {
+    /// The issuer of the OpenID Connect Provider
     pub issuer: String,
     /// The authorization endpoint to start the code flow
     pub authorization_endpoint: String,


### PR DESCRIPTION
For #13: Forward the access token and/or ID token as request header with custom names and prefixes.