### PR TITLE
Add state verification to OIDC callback (#7), Rewrite cookie logic (#19), Rename Session Cookie & Config Value Checks (#33)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,17 @@ jobs:
       - name: Cargo Deny
         uses: EmbarkStudios/cargo-deny-action@v1
 
-      - name: Run tests
-        run: |
-          rustc --version && cargo --version
-          cargo clippy --release --all-targets --target=wasm32-wasi
-          cargo fmt -- --check
-          cargo test --workspace --verbose
+      - name: Rust version
+        run: rustc --version && cargo --version
+
+      - name: Clippy
+        run: cargo clippy --release --all-targets --target=wasm32-wasi
+
+      - name: Fmt
+        run: cargo fmt -- --check
+
+      - name: Test
+        run: cargo test --workspace --verbose
+
+      - name: Build
+        run: cargo build --release --target wasm32-wasi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,6 @@ jobs:
       - name: Run tests
         run: |
           rustc --version && cargo --version
-          cargo clippy
+          cargo clippy --release --all-targets --target=wasm32-wasi
+          cargo fmt -- --check
           cargo test --workspace --verbose

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.4
+
+* Check for three Host Headers
+* Default URL Headers
+* Envoy Docker Image to 1.29
+* Missing config in Configmap added
+* OIDC Plugin Name added
+* Fix Pre Built Deployment File Mounting
+* GHCR Image Push
+
 ## v0.3.3
 
 * Fix Docker-Build Version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+## v0.3.3
+
+* Fix Docker-Build Version
+
+## v0.3.2
+
+* Add Kubernetes examples
+* Explain why to use this repo
+
+## v0.3.1
+
+* Filter Proxy Cookies and do not forward them to the backend
+
+## v0.3.0
+
+* Add support for forwarding the access token to the backend
+
+## v0.2.0
+
+* Make Token Validation optional and configurable
+* Support for other key types added
+* Replace JWT Simple crate with modified one
+
+## v0.1.4
+
+* Replace Rust Docker Image with own one
+
+## v0.1.1
+
+* Workflows for Build & Docs
+
+## v0.1.0
+
+* Redirect to Authorization Endpoint
+* Exchange Code for Token
+* Validate Token
+* Encrypt and Decrypt Cookies
+* Load Configuration from Endpoint
+* Configuration options
+* Exclude Hosts, Paths, URLs
+* Reload Interval
+* Docker-Compose Example

--- a/README.md
+++ b/README.md
@@ -85,28 +85,29 @@ cargo doc --document-private-items --open
 
 The plugin is configured via the `envoy.yaml`-file. The following configuration options are required:
 
-| Name | Type | Description | Example |
-| ---- | ---- | ----------- | ------- |
-| `config_endpoint` | `string` | The open id configuration endpoint. | `https://accounts.google.com/.well-known/openid-configuration` |
-| `reload_interval_in_hours` | `u64` | The interval in hours, after which the OIDC configuration is reloaded. | `24` |
-| `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filter. | `["localhost:10000"]` |
-| `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` |
-| `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` |
-| `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` |
-| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` |
-| `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` |
-| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` |
-| `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` |
-| `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` |
-| `token_validation` | bool | Whether to validate the token or not. | `true` |
-| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q=` |
-| `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` |
-| `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` |
-| `client_id` | `string` | The client ID, for getting and exchanging the code. | `wasm-oidc-plugin` |
-| `scope` | `string` | The scope, to validate | `openid email` |
-| `claims` | `string` | The claims, to validate. Make sure to escape quotes with a backslash | `{\"id_token\":{\"groups\":null,\"username\":null}}` |
-| `client_secret` | `string` | The client secret, that is used to authenticate with the `authorization_endpoint`. | `secret` |
-| `audience` | `string` | The audience, that is used to validate the token. | `wasm-oidc-plugin` |
+| Name | Type | Description | Example | Required |
+| ---- | ---- | ----------- | ------- | -------- |
+| `config_endpoint` | `string` | The open id configuration endpoint. | `https://accounts.google.com/.well-known/openid-configuration` | `true` |
+| `reload_interval_in_hours` | `u64` | The interval in hours, after which the OIDC configuration is reloaded. | `24` | `true` |
+| `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filter. | `["localhost:10000"]` | `false` |
+| `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` | `false` |
+| `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` | `false` |
+| `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` | `false` |
+| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` | `false` |
+| `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` | `false` |
+| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` | `false` |
+| `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` | `true` |
+| `filter_plugin_cookies | `bool` | Whether to filter the cookies that are managed and controlled by the plugin (namely cookie_name and `nonce`). | `true` | `true` |
+| `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` | `true` |
+| `token_validation` | bool | Whether to validate the token or not. | `true` | `true` |
+| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q=` | `true` |
+| `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` | `true` |
+| `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` | `true` |
+| `client_id` | `string` | The client ID, for getting and exchanging the code. | `wasm-oidc-plugin` | `true` |
+| `scope` | `string` | The scope, to validate | `openid email` | `true` |
+| `claims` | `string` | The claims, to validate. Make sure to escape quotes with a backslash | `{\"id_token\":{\"groups\":null,\"username\":null}}` | `true` |
+| `client_secret` | `string` | The client secret, that is used to authenticate with the `authorization_endpoint`. | `secret` | `true` |
+| `audience` | `string` | The audience, that is used to validate the token. | `wasm-oidc-plugin` | `true` |
 
 With these configuration options, the plugin starts and loads more information itself such as the OIDC providers public keys, issuer, etc.
 

--- a/README.md
+++ b/README.md
@@ -87,27 +87,27 @@ The plugin is configured via the `envoy.yaml`-file. The following configuration 
 
 | Name | Type | Description | Example | Required |
 | ---- | ---- | ----------- | ------- | -------- |
-| `config_endpoint` | `string` | The open id configuration endpoint. | `https://accounts.google.com/.well-known/openid-configuration` | `true` |
-| `reload_interval_in_hours` | `u64` | The interval in hours, after which the OIDC configuration is reloaded. | `24` | `true` |
-| `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filter. | `["localhost:10000"]` | `false` |
-| `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` | `false` |
-| `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` | `false` |
-| `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` | `false` |
-| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` | `false` |
-| `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` | `false` |
-| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` | `false` |
-| `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` | `true` |
-| `filter_plugin_cookies | `bool` | Whether to filter the cookies that are managed and controlled by the plugin (namely cookie_name and `nonce`). | `true` | `true` |
-| `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` | `true` |
-| `token_validation` | bool | Whether to validate the token or not. | `true` | `true` |
-| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q=` | `true` |
-| `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` | `true` |
-| `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` | `true` |
-| `client_id` | `string` | The client ID, for getting and exchanging the code. | `wasm-oidc-plugin` | `true` |
-| `scope` | `string` | The scope, to validate | `openid email` | `true` |
-| `claims` | `string` | The claims, to validate. Make sure to escape quotes with a backslash | `{\"id_token\":{\"groups\":null,\"username\":null}}` | `true` |
-| `client_secret` | `string` | The client secret, that is used to authenticate with the `authorization_endpoint`. | `secret` | `true` |
-| `audience` | `string` | The audience, that is used to validate the token. | `wasm-oidc-plugin` | `true` |
+| `config_endpoint` | `string` | The open id configuration endpoint. | `https://accounts.google.com/.well-known/openid-configuration` | ✅ |
+| `reload_interval_in_hours` | `u64` | The interval in hours, after which the OIDC configuration is reloaded. | `24` | ✅ |
+| `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filter. | `["localhost:10000"]` | ❌ |
+| `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` | ❌ |
+| `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` | ❌ |
+| `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` | ❌ |
+| `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` | ❌ |
+| `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` | ❌ |
+| `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` | ❌ |
+| `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` | ✅ |
+| `filter_plugin_cookies | `bool` | Whether to filter the cookies that are managed and controlled by the plugin (namely cookie_name and `nonce`). | `true` | ✅ |
+| `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` | ✅ |
+| `token_validation` | bool | Whether to validate the token or not. | `true` | ✅ |
+| `aes_key` | `string` | A base64 encoded AES-256 Key: `openssl rand -base64 32` | `SFDUGDbOsRzSZbv+mvnZdu2x6+Hqe2WRaBABvfxmh3Q=` | ✅ |
+| `authority` | `string` | The authority of the `authorization_endpoint`. | `accounts.google.com` | ✅ |
+| `redirect_uri` | `string` | The redirect URI, that the `authorization_endpoint` will redirect to. | `http://localhost:10000/oidc/callback` | ✅ |
+| `client_id` | `string` | The client ID, for getting and exchanging the code. | `wasm-oidc-plugin` | ✅ |
+| `scope` | `string` | The scope, to validate | `openid email` | ✅ |
+| `claims` | `string` | The claims, to validate. Make sure to escape quotes with a backslash | `{\"id_token\":{\"groups\":null,\"username\":null}}` | ✅ |
+| `client_secret` | `string` | The client secret, that is used to authenticate with the `authorization_endpoint`. | `secret` | ✅ |
+| `audience` | `string` | The audience, that is used to validate the token. | `wasm-oidc-plugin` | ✅ |
 
 With these configuration options, the plugin starts and loads more information itself such as the OIDC providers public keys, issuer, etc.
 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -43,7 +43,7 @@ static_resources:
                           id_token_header_name: # or "X-Id-Token"
                           id_token_header_prefix: "Bearer "
 
-                          cookie_name: "oidcSession"
+                          cookie_name: "oidcSession" # max. 32 characters
                           filter_plugin_cookies: true # or false
                           cookie_duration: 86400 # in seconds
                           token_validation: true # or false

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -44,6 +44,7 @@ static_resources:
                           id_token_header_prefix: "Bearer "
 
                           cookie_name: "oidcSession"
+                          filter_plugin_cookies: true # or false
                           cookie_duration: 86400 # in seconds
                           token_validation: true # or false
                           aes_key: "i-am-a-forty-four-characters-long-string-key" # generate with `openssl rand -base64 32`

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ use crate::responses::SigningKey;
 /// OpenID Connect Flow.
 #[derive(Clone, Debug)]
 pub struct OpenIdConfig {
-
     // Everything relevant for the Code Flow
     /// The URL of the authorization endpoint
     pub auth_endpoint: Url,
@@ -34,7 +33,6 @@ pub struct OpenIdConfig {
 /// `envoy.yaml`
 #[derive(Clone, Debug, Deserialize)]
 pub struct PluginConfiguration {
-
     /// Config endpoint for the plugin.
     pub config_endpoint: String,
     /// Reload interval in hours

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,9 @@ pub struct PluginConfiguration {
     // Cookie settings
     /// The cookie name that will be used for the session cookie
     pub cookie_name: String,
+    /// Filter out the cookies created and controlled by the plugin
+    /// If the value is true, the cookies will be filtered out
+    pub filter_plugin_cookies: bool,
     /// The cookie duration in seconds
     pub cookie_duration: u64,
     /// Option to skip Token Validation

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -1,19 +1,21 @@
-// std
-use std::fmt::Debug;
+// aes_gcm
+use aes_gcm::{aead::AeadMut, Aes256Gcm, Nonce};
+
+// base64
+use base64::{engine::general_purpose::STANDARD_NO_PAD as base64engine, Engine as _};
+
+// jwt_simple
+use jwt_simple::reexports::coarsetime::Duration;
+
+// log
+use log::{debug, warn};
 
 // serde
 use serde::{Deserialize, Serialize};
 use serde_json;
 
-// log
-use log::{warn,debug};
-
-// base64
-use base64::{engine::general_purpose::STANDARD_NO_PAD as base64engine, Engine as _};
-
-// aes_gcm
-use aes_gcm::{Aes256Gcm, Nonce, aead::AeadMut};
-
+// std
+use std::fmt::Debug;
 /// Struct parse the cookie from the request into a struct in order to access the fields and
 /// also to save the cookie on the client side
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,99 +33,129 @@ pub struct AuthorizationState {
     pub id_token: String,
 }
 
-/// Struct that holds the encoded cookie and the encoded nonce as well as the access token and the id token
-pub struct EncodedCookies {
-    /// Encoded cookie
-    pub encoded_cookie: String,
-    /// Access token
-    pub access_token: String,
-    /// ID token
-    pub id_token: String,
+/// Struct that holds all information about the current session
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    /// Authorization state
+    pub authorization_state: Option<AuthorizationState>,
+    /// Original Path
+    pub original_path: String,
+    /// PKCE Code Verifier
+    pub code_verifier: String,
+    /// State
+    pub state: String,
 }
 
-/// Implementation of the AuthorizationState struct
-impl AuthorizationState {
+impl<'a> Session {
 
-    /// Create a new encoded cookie from the response coming from the Token Endpoint
-    pub fn create_cookie_from_response(mut cipher: Aes256Gcm, res: &[u8], nonce: String) -> Result<EncodedCookies, String> {
-
-        // Format the response into a slice and parse it in a struct
-        match serde_json::from_slice::<AuthorizationState>(&res) {
-
-            // If deserialization was successful, return the encrypted and encoded cookie
-            Ok(state) => {
-
-                // Decode nonce using base64
-                let decoded_nonce = base64engine.decode(nonce).unwrap();
-                let nonce = Nonce::from_slice(decoded_nonce.as_slice());
-
-                // Encrypt cookie
-                let encrypted_cookie = cipher.encrypt(&nonce, serde_json::to_vec(&state).unwrap().as_slice()).unwrap();
-
-                // Encode cookie
-                let encoded_cookie = base64engine.encode(encrypted_cookie.as_slice());
-
-                Ok(EncodedCookies {
-                    encoded_cookie,
-                    access_token: state.access_token,
-                    id_token: state.id_token,
-                })
-            },
-            // If the cookie cannot be parsed into a struct, return an error
-            Err(e) => {
-                warn!("the token response is not in the required format: {}", e);
-                return Err(e.to_string())
-            }
-        }
-    }
-
-    /// Decode cookie, parse into a struct in order to access the fields and
-    /// validate the ID Token
-    pub fn decode_and_decrypt_cookie(cookie: String, mut cipher: Aes256Gcm, nonce: String) -> Result<AuthorizationState, String> {
+    /// Create a new session, encrypt it and encode it
+    pub fn encrypt_and_encode(self, mut cipher: Aes256Gcm, encoded_nonce: String) -> String {
 
         // Decode nonce using base64
-        let decoded_nonce = match base64engine.decode(nonce.as_bytes()) {
-            Ok(s) => s,
+        let decoded_nonce = base64engine.decode(encoded_nonce.as_bytes()).unwrap();
+
+        // Build nonce from decoded nonce
+        let nonce = Nonce::from_slice(&decoded_nonce.as_slice());
+
+        // Encrypt cookie
+        let encrypted_cookie = cipher
+            .encrypt(&nonce, serde_json::to_vec(&self).unwrap().as_slice())
+            .unwrap();
+
+        // Encode cookie and return
+        return base64engine.encode(encrypted_cookie.as_slice());
+    }
+
+    /// Make the cookie values from the encoded cookie
+    pub fn make_cookie_values(encoded_cookie: String, cookie_name: String, cookie_duration: Duration) -> Vec<String> {
+
+        // Split every 4000 bytes
+        let cookie_parts = encoded_cookie
+            .as_bytes()
+            .chunks(4000)
+            .map(|chunk| std::str::from_utf8(chunk)
+            .expect("auth_cookie is base64 encoded, which means ASCII, which means one character = one byte, so this is valid"));
+
+        let mut cookie_values = vec![];
+
+        // Build the cookie values
+        for (i, cookie_part) in cookie_parts.enumerate() {
+            let cookie_value = String::from(format!(
+                "{}-{}={}; Path=/; HttpOnly; Secure; Max-Age={:?}",
+                cookie_name, i, cookie_part, cookie_duration
+            ));
+            cookie_values.push(cookie_value);
+        }
+
+        return cookie_values;
+    }
+
+    /// Make the Set-Cookie headers from the encoded cookie
+    pub fn make_set_cookie_headers(cookie_values: &'a Vec<String>) -> Vec<(&'static str, &'a str)> {
+
+        // Build the cookie headers
+        let set_cookie_headers: Vec<(&str, &str)> = cookie_values
+            .iter()
+            .map(|v| ("Set-Cookie", v.as_str()))
+            .collect();
+
+        // Return the cookie headers
+        return set_cookie_headers;
+    }
+
+    /// Decode cookie, parse into a struct in order to access the fields
+    pub fn decode_and_decrypt(encoded_cookie: String, mut cipher: Aes256Gcm, encoded_nonce: String) -> Result<Session, String> {
+
+        // Decode nonce using base64
+        // TODO: Idiomatically handle the error
+        let decoded_nonce = match base64engine.decode(encoded_nonce.as_bytes()) {
+            Ok(nonce) => nonce,
             Err(e) => {
-                warn!("the nonce could not be decoded: {}", e);
+                warn!("the nonce didn't match the expected format: {}", e);
                 return Err(e.to_string());
             }
         };
-        let nonce = aes_gcm::Nonce::from_slice(decoded_nonce.as_slice());
+
+        // Build nonce from decoded nonce
+        let nonce = Nonce::from_slice(decoded_nonce.as_slice());
 
         // Decode cookie using base64
-        let decoded_cookie = match base64engine.decode(cookie.as_bytes()) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("the cookie could not be decoded: {}", e);
-                return Err(e.to_string());
-            }
-        };
-
-        // Decrypt with cipher
-        let decrypted_cookie = match cipher.decrypt(nonce, decoded_cookie.as_slice()) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("the cookie could not be decrypted: {}", e);
-                return Err(e.to_string());
-            }
-        };
-
-        debug!("decrypted cookie");
-
-        // Parse cookie into a struct
-        match serde_json::from_slice::<AuthorizationState>(&decrypted_cookie) {
-
-            // If deserialization was successful, set the cookie and resume the request
-            Ok(state) => {
-                debug!("authorization state: {:?}", state);
-                return Ok(state)
-            },
-            // If the cookie cannot be parsed into a struct, return an error
+        let decoded_cookie = match base64engine.decode(encoded_cookie.as_bytes()) {
+            Ok(cookie) => cookie,
             Err(e) => {
                 warn!("the cookie didn't match the expected format: {}", e);
-                return Err(e.to_string())
+                return Err(e.to_string());
             }
-        }
+        }; // TODO: Idiomatically handle the error
+
+        // Decrypt cookie
+        // TODO: Idiomatically handle the error
+        match cipher.decrypt(nonce, decoded_cookie.as_slice()) {
+
+            // If decryption was successful, continue
+            Ok(decrypted_cookie) => {
+                debug!("decrypted cookie: {:?}", decrypted_cookie);
+
+                // Parse cookie into a struct
+                match serde_json::from_slice::<Session>(&decrypted_cookie) {
+
+                    // If deserialization was successful, return the session
+                    Ok(session) => {
+                        debug!("authorization state: {:?}", session);
+                        return Ok(session);
+                    }
+                    // If the cookie cannot be parsed into a struct, return an error
+                    Err(e) => {
+                        warn!("the cookie didn't match the expected format: {}", e);
+                        return Err(e.to_string());
+                    }
+                }
+            }
+            // If decryption failed, return an error
+            Err(e) => {
+                warn!("decryption failed: {}", e);
+                return Err(e.to_string());
+            }
+        };
     }
 }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -73,7 +73,7 @@ impl AuthorizationState {
             },
             // If the cookie cannot be parsed into a struct, return an error
             Err(e) => {
-                warn!("The token response is not in the required format: {}", e);
+                warn!("the token response is not in the required format: {}", e);
                 return Err(e.to_string())
             }
         }
@@ -87,18 +87,17 @@ impl AuthorizationState {
         let decoded_nonce = match base64engine.decode(nonce.as_bytes()) {
             Ok(s) => s,
             Err(e) => {
-                warn!("The nonce could not be decoded: {}", e);
+                warn!("the nonce could not be decoded: {}", e);
                 return Err(e.to_string());
             }
         };
         let nonce = aes_gcm::Nonce::from_slice(decoded_nonce.as_slice());
-        debug!("Nonce: {:?}", nonce);
 
         // Decode cookie using base64
         let decoded_cookie = match base64engine.decode(cookie.as_bytes()) {
             Ok(s) => s,
             Err(e) => {
-                warn!("The cookie could not be decoded: {}", e);
+                warn!("the cookie could not be decoded: {}", e);
                 return Err(e.to_string());
             }
         };
@@ -107,22 +106,24 @@ impl AuthorizationState {
         let decrypted_cookie = match cipher.decrypt(nonce, decoded_cookie.as_slice()) {
             Ok(s) => s,
             Err(e) => {
-                warn!("The cookie could not be decrypted: {}", e);
+                warn!("the cookie could not be decrypted: {}", e);
                 return Err(e.to_string());
             }
         };
+
+        debug!("decrypted cookie");
 
         // Parse cookie into a struct
         match serde_json::from_slice::<AuthorizationState>(&decrypted_cookie) {
 
             // If deserialization was successful, set the cookie and resume the request
             Ok(state) => {
-                debug!("State: {:?}", state);
+                debug!("authorization state: {:?}", state);
                 return Ok(state)
             },
             // If the cookie cannot be parsed into a struct, return an error
             Err(e) => {
-                warn!("The cookie didn't match the expected format: {}", e);
+                warn!("the cookie didn't match the expected format: {}", e);
                 return Err(e.to_string())
             }
         }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -52,7 +52,7 @@ impl<'a> Session {
     pub fn encrypt_and_encode(self, mut cipher: Aes256Gcm, encoded_nonce: String) -> String {
 
         // Decode nonce using base64
-        let decoded_nonce = base64engine.decode(encoded_nonce.as_bytes()).unwrap();
+        let decoded_nonce = base64engine.decode(encoded_nonce.as_bytes()).expect("nonce didn't match the expected format");
 
         // Build nonce from decoded nonce
         let nonce = Nonce::from_slice(&decoded_nonce.as_slice());
@@ -72,7 +72,7 @@ impl<'a> Session {
     /// * `cookie_name` - Name of the cookie
     /// * `cookie_duration` - Duration of the cookie in seconds
     /// * `number_current_cookies` - Number of cookies that are currently set (important because otherwise decryption will fail if older and expired cookies are still present)
-    pub fn make_cookie_values(encoded_cookie: String, cookie_name: String, cookie_duration: u64, number_current_cookies: u64) -> Vec<String> {
+    pub fn make_cookie_values(encoded_cookie: String, cookie_name: &str, cookie_duration: u64, number_current_cookies: u64) -> Vec<String> {
 
         // Split every 4000 bytes
         let cookie_parts = encoded_cookie

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -47,7 +47,7 @@ impl Session {
     /// Create a new session, encrypt it and encode it by using the given cipher and nonce
     /// * `cipher` - Cipher used to encrypt the cookie
     /// * `encoded_nonce` - Nonce used to encrypt the cookie
-    pub fn encrypt_and_encode(self, mut cipher: Aes256Gcm, encoded_nonce: String) -> String {
+    pub fn encrypt_and_encode(&self, mut cipher: Aes256Gcm, encoded_nonce: String) -> String {
         // Decode nonce using base64
         let decoded_nonce = base64engine
             .decode(encoded_nonce.as_bytes())

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -43,7 +43,7 @@ pub struct Session {
     pub state: String,
 }
 
-impl<'a> Session {
+impl Session {
     /// Create a new session, encrypt it and encode it by using the given cipher and nonce
     /// * `cipher` - Cipher used to encrypt the cookie
     /// * `encoded_nonce` - Nonce used to encrypt the cookie
@@ -109,7 +109,7 @@ impl<'a> Session {
 
     /// Make the Set-Cookie headers from the cookie values
     /// * `cookie_values` - Cookie values to be set in the Set-Cookie headers
-    pub fn make_set_cookie_headers(cookie_values: &'a Vec<String>) -> Vec<(&'static str, &'a str)> {
+    pub fn make_set_cookie_headers(cookie_values: &[String]) -> Vec<(&'static str, &str)> {
         // Build the cookie headers
         let set_cookie_headers: Vec<(&str, &str)> = cookie_values
             .iter()

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -134,7 +134,10 @@ impl Session {
         let decoded_nonce = match base64engine.decode(encoded_nonce.as_bytes()) {
             Ok(nonce) => nonce,
             Err(e) => {
-                return Err(format!("the nonce didn't match the expected format: {}", e.to_string()));
+                return Err(format!(
+                    "the nonce didn't match the expected format: {}",
+                    e.to_string()
+                ));
             }
         };
 

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -64,7 +64,7 @@ impl<'a> Session {
     }
 
     /// Make the cookie values from the encoded cookie
-    pub fn make_cookie_values(encoded_cookie: String, cookie_name: String, cookie_duration: u64) -> Vec<String> {
+    pub fn make_cookie_values(encoded_cookie: String, cookie_name: String, cookie_duration: u64, number_current_cookies: u64) -> Vec<String> {
 
         // Split every 4000 bytes
         let cookie_parts = encoded_cookie
@@ -83,6 +83,12 @@ impl<'a> Session {
                 cookie_duration
             ));
             cookie_values.push(cookie_value);
+        }
+
+        // Overwrite the old cookies because decryption will fail if older and expired cookies are
+        // still present.
+        for i in cookie_values.len()..number_current_cookies as usize {
+            cookie_values.push(format!("{}-{}=; Path=/; HttpOnly; Secure; Max-Age=0", cookie_name, i));
         }
 
         return cookie_values;

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -148,8 +148,7 @@ impl Session {
         let decoded_cookie = match base64engine.decode(encoded_cookie.as_bytes()) {
             Ok(cookie) => cookie,
             Err(e) => {
-                warn!("the cookie didn't match the expected format: {}", e);
-                return Err(e.to_string());
+                return Err(format!("decoding the cookie failed: {}", e.to_string()));
             }
         }; // TODO: Idiomatically handle the error
 
@@ -166,17 +165,14 @@ impl Session {
                         Ok(session)
                     }
                     // If the cookie cannot be parsed into a struct, return an error
-                    Err(e) => {
-                        warn!("the cookie didn't match the expected format: {}", e);
-                        Err(e.to_string())
-                    }
+                    Err(e) => Err(format!(
+                        "the cookie didn't match the expected format: {}",
+                        e.to_string()
+                    )),
                 }
             }
             // If decryption failed, return an error
-            Err(e) => {
-                warn!("decryption failed: {}", e.to_string());
-                Err(e.to_string())
-            }
+            Err(e) => Err(format!("decryption failed: {}", e.to_string())),
         }
     }
 }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -134,8 +134,7 @@ impl Session {
         let decoded_nonce = match base64engine.decode(encoded_nonce.as_bytes()) {
             Ok(nonce) => nonce,
             Err(e) => {
-                warn!("the nonce didn't match the expected format: {}", e);
-                return Err(e.to_string());
+                return Err(format!("the nonce didn't match the expected format: {}", e.to_string()));
             }
         };
 

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -9,7 +9,6 @@ use log::{debug, warn};
 
 // serde
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 // std
 use std::fmt::Debug;
@@ -55,11 +54,11 @@ impl<'a> Session {
             .expect("nonce didn't match the expected format");
 
         // Build nonce from decoded nonce
-        let nonce = Nonce::from_slice(&decoded_nonce.as_slice());
+        let nonce = Nonce::from_slice(decoded_nonce.as_slice());
 
         // Encrypt cookie
         let encrypted_cookie = cipher
-            .encrypt(&nonce, serde_json::to_vec(&self).unwrap().as_slice())
+            .encrypt(nonce, serde_json::to_vec(&self).unwrap().as_slice())
             .unwrap();
 
         // Encode cookie and return
@@ -89,10 +88,10 @@ impl<'a> Session {
 
         // Build the cookie values
         for (i, cookie_part) in cookie_parts.enumerate() {
-            let cookie_value = String::from(format!(
+            let cookie_value = format!(
                 "{}-{}={}; Path=/; HttpOnly; Secure; Max-Age={:?}",
                 cookie_name, i, cookie_part, cookie_duration
-            ));
+            );
             cookie_values.push(cookie_value);
         }
 
@@ -105,7 +104,7 @@ impl<'a> Session {
             ));
         }
 
-        return cookie_values;
+        cookie_values
     }
 
     /// Make the Set-Cookie headers from the cookie values
@@ -118,7 +117,7 @@ impl<'a> Session {
             .collect();
 
         // Return the cookie headers
-        return set_cookie_headers;
+        set_cookie_headers
     }
 
     /// Decode cookie, parse into a struct in order to access the fields
@@ -162,20 +161,20 @@ impl<'a> Session {
                     // If deserialization was successful, return the session
                     Ok(session) => {
                         debug!("authorization state: {:?}", session);
-                        return Ok(session);
+                        Ok(session)
                     }
                     // If the cookie cannot be parsed into a struct, return an error
                     Err(e) => {
                         warn!("the cookie didn't match the expected format: {}", e);
-                        return Err(e.to_string());
+                        Err(e.to_string())
                     }
                 }
             }
             // If decryption failed, return an error
             Err(e) => {
                 warn!("decryption failed: {}", e.to_string());
-                return Err(e.to_string());
+                Err(e.to_string())
             }
-        };
+        }
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -181,12 +181,12 @@ impl RootContext for OidcDiscovery {
                 debug!("creating http context with root context information");
 
                 // Return the http context.
-                return Some(Box::new(ConfiguredOidc {
+                Some(Box::new(ConfiguredOidc {
                     open_id_config: open_id_config.clone(),
                     plugin_config: plugin_config.clone(),
                     token_id: None,
                     cipher: self.cipher.clone().unwrap(),
-                }));
+                }))
             }
 
             // If the plugin is not ready, return the http context in `Unconfigured` state and add the
@@ -198,9 +198,9 @@ impl RootContext for OidcDiscovery {
                 self.waiting.lock().unwrap().push(context_id);
 
                 // Return the http context in `Unconfigured` state.
-                return Some(Box::new(PauseRequests {
+                Some(Box::new(PauseRequests {
                     original_path: None,
-                }));
+                }))
             }
         }
     }
@@ -246,7 +246,6 @@ impl RootContext for OidcDiscovery {
                     }
                     Err(e) => warn!("error dispatching oidc call: {:?}", e),
                 }
-                return;
             }
 
             // If the plugin is in Loading `LoadingJwks` state, the public keys are loaded from the
@@ -394,7 +393,7 @@ impl Context for OidcDiscovery {
                         debug!("parsed jwks body: {:?}", jwks_response);
 
                         // Check if keys are present
-                        if jwks_response.keys.len() == 0 {
+                        if jwks_response.keys.is_empty() {
                             warn!("no keys found in jwks response, retry in 1 minute");
                             self.set_tick_period(Duration::from_secs(60));
                             return;
@@ -490,7 +489,7 @@ impl OidcDiscovery {
         }
 
         let cookies_name_regex = Regex::new(r"[\w\d-]+").unwrap();
-        if plugin_config.cookie_name.len() == 0
+        if plugin_config.cookie_name.is_empty()
             || !cookies_name_regex.is_match(&plugin_config.cookie_name)
         {
             return Err("`cookie_name` is empty or not valid meaning that it contains invalid characters like ;, =, :, /, space".to_string());
@@ -507,37 +506,37 @@ impl OidcDiscovery {
         }
 
         // Authority
-        if plugin_config.authority.len() == 0 {
+        if plugin_config.authority.is_empty() {
             return Err("`authority` is empty".to_string());
         }
 
         // Redirect Uri
-        if plugin_config.redirect_uri.len() == 0 {
+        if plugin_config.redirect_uri.is_empty() {
             return Err("`redirect_uri` is empty".to_string());
         }
 
         // Client Id
-        if plugin_config.client_id.len() == 0 {
+        if plugin_config.client_id.is_empty() {
             return Err("`client_id` is empty".to_string());
         }
 
         // Scope
-        if plugin_config.scope.len() == 0 {
+        if plugin_config.scope.is_empty() {
             return Err("`scope` is empty".to_string());
         }
 
         // Claims
-        if plugin_config.claims.len() == 0 {
+        if plugin_config.claims.is_empty() {
             return Err("`claims` is empty".to_string());
         }
 
         // Client Secret
-        if plugin_config.client_secret.len() == 0 {
+        if plugin_config.client_secret.is_empty() {
             return Err("client_secret is empty".to_string());
         }
 
         // Audience
-        if plugin_config.audience.len() == 0 {
+        if plugin_config.audience.is_empty() {
             return Err("audience is empty".to_string());
         }
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -75,6 +75,7 @@ pub struct OidcDiscovery {
 /// - LoadingJwks: The jwks configuration is being loaded
 /// - Ready: The plugin is ready
 /// Each state has a different set of fields which are needed for that specific state.
+#[allow(clippy::large_enum_variant)]
 pub enum OidcRootState {
     /// State when the plugin needs to load the plugin configuration
     Uninitialized,

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -231,7 +231,7 @@ impl RootContext for OidcDiscovery {
             } => {
 
                 // Tick every 250ms to not overload the openid configuration endpoint.
-                self.set_tick_period(Duration::from_millis(250));
+                self.set_tick_period(Duration::from_millis(300));
 
                 // Make call to openid configuration endpoint
                 // The response is handled in `on_http_call_response`.
@@ -496,13 +496,13 @@ impl OidcDiscovery {
         }
 
         if plugin_config.cookie_name.len() == 0
-            && plugin_config.cookie_name.contains(";")
-            && plugin_config.cookie_name.contains(",")
-            && plugin_config.cookie_name.contains(" ")
-            && plugin_config.cookie_name.contains("=")
-            && plugin_config.cookie_name.contains(":")
-            && plugin_config.cookie_name.contains("/") {
-            return Err("`cookie_name` is not valid, contains invalid characters like ;, =, :, /, space".to_string());
+            || plugin_config.cookie_name.contains(";")
+            || plugin_config.cookie_name.contains(",")
+            || plugin_config.cookie_name.contains(" ")
+            || plugin_config.cookie_name.contains("=")
+            || plugin_config.cookie_name.contains(":")
+            || plugin_config.cookie_name.contains("/") {
+            return Err("`cookie_name` is empty or not valid meaning that it contains invalid characters like ;, =, :, /, space".to_string());
         }
 
         // Cookie Duration

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -141,7 +141,7 @@ impl RootContext for OidcDiscovery {
                                 info!("plugin configuration is valid");
                             }
                             Err(e) => {
-                                warn!("plugin configuration is invalid: {:?}", e);
+                                panic!("plugin configuration is invalid: {:?}", e);
                             }
                         }
 
@@ -482,17 +482,17 @@ impl OidcDiscovery {
 
         // Config Endpoint
         if Url::parse(&plugin_config.config_endpoint).is_err() {
-            return Err("config endpoint is not a valid url".to_string());
+            return Err("`config_endpoint` is not a valid url".to_string());
         }
 
         // Reload Interval
         if plugin_config.reload_interval_in_h == 0 {
-            return Err("reload interval is 0".to_string());
+            return Err("`reload_interval` is 0".to_string());
         }
 
         // Cookie Name
         if plugin_config.cookie_name.len() > 32 {
-            return Err("cookie name is too long, max 32".to_string());
+            return Err("`cookie_name` is too long, max 32".to_string());
         }
 
         if plugin_config.cookie_name.len() == 0
@@ -502,57 +502,47 @@ impl OidcDiscovery {
             && plugin_config.cookie_name.contains("=")
             && plugin_config.cookie_name.contains(":")
             && plugin_config.cookie_name.contains("/") {
-            return Err("cookie name is not valid, contains invalid characters like ;, =, :, /, space".to_string());
-        }
-
-        // Filter plugin config flag
-        if plugin_config.filter_plugin_cookies != true && plugin_config.filter_plugin_cookies != false {
-            return Err("filter plugin cookies is not a boolean".to_string());
+            return Err("`cookie_name` is not valid, contains invalid characters like ;, =, :, /, space".to_string());
         }
 
         // Cookie Duration
         if plugin_config.cookie_duration == 0 {
-            return Err("cookie duration is 0".to_string());
-        }
-
-        // Token validation flag
-        if plugin_config.token_validation != true && plugin_config.token_validation != false {
-            return Err("validate token is not a boolean".to_string());
+            return Err("`cookie_duration` is 0".to_string());
         }
 
         // AES Key
         if plugin_config.aes_key.len() != 44 {
-            return Err("aes key is not 44 characters long, but must be".to_string());
+            return Err("`aes_key` is not 44 characters long, but must be".to_string());
         }
 
         // Authority
         if plugin_config.authority.len() == 0 {
-            return Err("authority is empty".to_string());
+            return Err("`authority` is empty".to_string());
         }
 
         // Redirect Uri
         if plugin_config.redirect_uri.len() == 0 {
-            return Err("redirect uri is empty".to_string());
+            return Err("`redirect_uri` is empty".to_string());
         }
 
         // Client Id
         if plugin_config.client_id.len() == 0 {
-            return Err("client id is empty".to_string());
+            return Err("`client_id` is empty".to_string());
         }
 
         // Scope
         if plugin_config.scope.len() == 0 {
-            return Err("scope is empty".to_string());
+            return Err("`scope` is empty".to_string());
         }
 
         // Claims
         if plugin_config.claims.len() == 0 {
-            return Err("claims is empty".to_string());
+            return Err("`claims` is empty".to_string());
         }
 
         // Client Secret
         if plugin_config.client_secret.len() == 0 {
-            return Err("client secret is empty".to_string());
+            return Err("client_secret is empty".to_string());
         }
 
         // Audience

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -168,7 +168,7 @@ impl RootContext for OidcDiscovery {
                 open_id_config,
                 plugin_config,
             } => {
-                debug!("Creating http context with root context information.");
+                debug!("creating http context with root context information");
 
                 // Return the http context.
                 return Some(Box::new(ConfiguredOidc {
@@ -182,7 +182,7 @@ impl RootContext for OidcDiscovery {
             // If the plugin is not ready, return the http context in `Unconfigured` state and add the
             // context id to the waiting queue.
             _ => {
-                warn!("Root context is not ready yet. Queueing http context.");
+                warn!("root context is not ready yet, queueing http context.");
 
                 // Add the context id to the waiting queue.
                 self.waiting.lock().unwrap().push(context_id);
@@ -327,7 +327,7 @@ impl Context for OidcDiscovery {
                     return;
                 }
 
-                debug!("loading from openid config endpoint");
+                debug!("received config response");
 
                 // Parse the response body as json.
                 let body = match self.get_http_call_response_body(0, _body_size) {
@@ -377,7 +377,7 @@ impl Context for OidcDiscovery {
                     return;
                 }
 
-                debug!("loading jwks");
+                debug!("received jwks response");
 
                 // Parse body
                 let body = self.get_http_call_response_body(0, _body_size).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,7 +542,9 @@ impl ConfiguredOidc {
                 let set_cookie_values = Session::make_cookie_values(
                     new_session.to_owned(),
                     self.plugin_config.cookie_name.clone(),
-                    self.plugin_config.cookie_duration);
+                    self.plugin_config.cookie_duration,
+                    self.get_number_of_cookies() as u64
+                );
 
                 // Build cookie headers
                 let mut set_cookie_headers = Session::make_set_cookie_headers(&set_cookie_values);
@@ -599,7 +601,9 @@ impl ConfiguredOidc {
         let set_cookie_values = Session::make_cookie_values(
             session,
             self.plugin_config.cookie_name.clone(),
-            self.plugin_config.cookie_duration);
+            self.plugin_config.cookie_duration,
+            self.get_number_of_cookies() as u64
+        );
 
         // Build cookie headers
         let mut headers = Session::make_set_cookie_headers(&set_cookie_values);
@@ -657,5 +661,11 @@ impl ConfiguredOidc {
             .join("");
 
         return cookie;
+    }
+
+    /// Helper function to get the number of cookies from the request headers.
+    pub fn get_number_of_cookies(&self) -> usize {
+        let cookie = self.get_http_request_header("cookie").unwrap_or_default();
+        cookie.split(";").count()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,9 +370,11 @@ impl ConfiguredOidc {
         allowed_audiences.insert(self.plugin_config.audience.to_string());
 
         // Define verification options
-        let mut verification_options = VerificationOptions::default();
-        verification_options.allowed_audiences = Some(allowed_audiences);
-        verification_options.allowed_issuers = Some(allowed_issuers);
+        let verification_options = VerificationOptions {
+            allowed_issuers: Some(allowed_issuers),
+            allowed_audiences: Some(allowed_audiences),
+            ..Default::default()
+        };
 
         // Iterate over all public keys
         for public_key in &self.open_id_config.public_keys {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,11 @@ impl ConfiguredOidc {
     /// the cookie from being forwarded to the upstream service.
     fn filter_proxy_cookies(&self) {
 
+        // Check if the filter_plugin_cookies option is set
+        if !self.plugin_config.filter_plugin_cookies {
+            return;
+        }
+
         // Get all cookies
         let all_cookies = self.get_http_request_header("cookie").unwrap_or_default();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl HttpContext for ConfiguredOidc {
                         vec![
                             ("Cache-Control", "no-cache"),
                         ],
-                    Some(b"Token exchange failed."));
+                    Some(b"Token exchange failed. Please try again or delete your cookies."));
                 }
             }
             return Action::Pause;
@@ -216,7 +216,7 @@ impl Context for ConfiguredOidc {
                     vec![
                         ("Cache-Control", "no-cache"),
                     ],
-                Some(b"Storing token in cookie failed."));
+                Some(b"Storing token in cookie failed. Please try again or delete your cookies."));
             }
         }
     }
@@ -429,7 +429,6 @@ impl ConfiguredOidc {
 
         // Compare state
         if state != session.state {
-            warn!("state does not match.");
             return Err("state does not match.".to_string());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ impl Context for ConfiguredOidc {
     }
 }
 
-/// Helper functions for the OIDCFlow struct.
+/// Helper functions for the ConfiguredOidc struct.
 impl ConfiguredOidc {
     /// Get the cookie of the HTTP request by name
     /// The cookie is searched in the request headers. If the cookie is found, the value is returned.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,8 @@ impl ConfiguredOidc {
         let state = callback_params.state;
         let code = callback_params.code;
         debug!("authorization code: {}", code);
+        debug!("client state: {}", state);
+        debug!("cookie state: {}", session.state);
 
         // Compare state
         if state != session.state {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,8 +566,7 @@ impl ConfiguredOidc {
                 session.authorization_state = Some(authorization_state);
 
                 // Create new session
-                let new_session = session
-                    .encrypt_and_encode(self.cipher.clone(), encoded_nonce);
+                let new_session = session.encrypt_and_encode(self.cipher.clone(), encoded_nonce);
 
                 // Get original path
                 let original_path = session.original_path.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,6 @@ impl ConfiguredOidc {
 
                 // Create new session
                 let new_session = session
-                    .clone()
                     .encrypt_and_encode(self.cipher.clone(), encoded_nonce);
 
                 // Get original path

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -95,15 +95,15 @@ impl From<JsonWebKey> for SigningKey {
                 }
 
                 // Decode and parse the public key components
-                let n_dec = base64engine_urlsafe.decode(&n).unwrap();
-                let e_dec = base64engine_urlsafe.decode(&e).unwrap();
+                let n_dec = base64engine_urlsafe.decode(n).unwrap();
+                let e_dec = base64engine_urlsafe.decode(e).unwrap();
 
                 info!("loaded RS256 public key");
 
-                return SigningKey::RS256PublicKey(
+                SigningKey::RS256PublicKey(
                     jwt_simple::algorithms::RS256PublicKey::from_components(&n_dec, &e_dec)
                         .unwrap(),
-                );
+                )
             } // Add more key types here
         }
     }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -49,11 +49,11 @@ pub enum JsonWebKey {
 }
 
 /// Enum that holds the public keys that will be used for the validation of the ID Token
-/// Essentially a wrapper to connect the `JWKsResponse` with the `jwt_simple` crate to use
-/// the `verify_token` function
+/// Essentially a wrapper to connect the `JWKsResponse` struct with the `jwt_simple` crate
+/// to use the `verify_token` function
 #[derive(Clone, Debug)]
 pub enum SigningKey {
-    /// A RSA Key of 256 bits
+    /// A [RSA Key](https://github.com/antonengelhardt/rust-jwt-simple/blob/master/src/algorithms/rsa.rs) of 256 bits
     RS256PublicKey(jwt_simple::algorithms::RS256PublicKey),
     // Add more key types here
 }
@@ -102,7 +102,7 @@ impl From<JsonWebKey> for SigningKey {
     }
 }
 
-/// Struct that defines how the callback looks like to serialize it better
+/// Struct that defines how the callback looks like to serialize it better with serde
 #[derive(Deserialize, Debug)]
 pub struct Callback {
     /// The code that is returned from the authorization endpoint

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -107,4 +107,6 @@ impl From<JsonWebKey> for SigningKey {
 pub struct Callback {
     /// The code that is returned from the authorization endpoint
     pub code: String,
+    /// The state that is returned from the authorization endpoint
+    pub state: String,
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -2,13 +2,20 @@
 use serde::Deserialize;
 
 // log
-use log::{info, debug};
+use log::{debug, info};
 
 // base64
-use {base64::engine::general_purpose::URL_SAFE_NO_PAD as base64engine_urlsafe, base64::Engine as _};
+use {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD as base64engine_urlsafe, base64::Engine as _,
+};
 
 // jwt_simple
-use jwt_simple::{self, prelude::{RSAPublicKeyLike, VerificationOptions, JWTClaims}, Error, claims::NoCustomClaims};
+use jwt_simple::{
+    self,
+    claims::NoCustomClaims,
+    prelude::{JWTClaims, RSAPublicKeyLike, VerificationOptions},
+    Error,
+};
 
 /// [OpenID Connect Discovery Response](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
 #[derive(Deserialize, Debug)]
@@ -60,10 +67,12 @@ pub enum SigningKey {
 
 /// A public key that can be used for the validation of the ID Token
 impl SigningKey {
-
     /// Function that calls the `verify_token` function of the `jwt_simple` crate for each key type
-    pub fn verify_token(&self, token: &str, options: VerificationOptions) -> Result<JWTClaims<NoCustomClaims>, Error> {
-
+    pub fn verify_token(
+        &self,
+        token: &str,
+        options: VerificationOptions,
+    ) -> Result<JWTClaims<NoCustomClaims>, Error> {
         match self {
             // RSA Key of 256 bits
             SigningKey::RS256PublicKey(key) => key.verify_token(token, Some(options)),
@@ -75,13 +84,11 @@ impl SigningKey {
 /// Implementation of the `From` trait for the `SigningKey` enum to convert the `JsonWebKey` into
 /// the `SigningKey` enum
 impl From<JsonWebKey> for SigningKey {
-
     /// Function that converts the `JsonWebKey` into the `SigningKey` enum
     fn from(key: JsonWebKey) -> Self {
         match key {
             // RSA Key of 256 bits
             JsonWebKey::RS256 { kty, n, e, .. } => {
-
                 // Check if the key is of type RSA
                 if kty != "RSA" {
                     debug!("key is not of type RSA although alg is RS256");
@@ -95,9 +102,9 @@ impl From<JsonWebKey> for SigningKey {
 
                 return SigningKey::RS256PublicKey(
                     jwt_simple::algorithms::RS256PublicKey::from_components(&n_dec, &e_dec)
-                .unwrap());
-            },
-            // Add more key types here
+                        .unwrap(),
+                );
+            } // Add more key types here
         }
     }
 }


### PR DESCRIPTION
Closes #7: Implement nonce as state parameter that is stored in a cookie as an additional security mechanism against CSRF. Followed [this guide](https://auth0.com/docs/secure/attack-protection/state-parameters)

Closes #19: Rewrite cookie logic to have one or more (depending on size) additional cookie next to the nonce. This gets rid of the code_verifier and original_path cookies.

Closes #33: Check values in config for valid inputs. Formats and type checking is done by serde_json.