### PR TITLE
k8s: use pod as httpbin target instead of public url, docker images for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Test and Build Wasm OIDC Plugin
+name: Test, Build and Deploy wasm-oidc-plugin
 
 on:
   push:
@@ -121,8 +121,7 @@ jobs:
           path: target/wasm32-wasi/release/wasm_oidc_plugin.wasm
 
   docker-image:
-    name: Build and push Docker image
-    needs: test
+    needs: [cargo-deny, clippy, fmt, test]
     runs-on: ubuntu-latest
 
     steps:
@@ -143,9 +142,8 @@ jobs:
           tags: antonengelhardt/wasm-oidc-plugin:latest
 
   ghcr-image:
-    name: Build and push GHCR image
     runs-on: ubuntu-latest
-    needs: test
+    needs: [cargo-deny, clippy, fmt, test]
     permissions:
       contents: read
       packages: write
@@ -168,7 +166,6 @@ jobs:
           docker push ghcr.io/antonengelhardt/wasm-oidc-plugin:latest
 
   deploy-demo:
-    name: Deploy to demo site
     needs: ghcr-image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       image: antonengelhardt/rust-docker-tools
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Rust version
         run: rustc --version && cargo --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/antonengelhardt/rust-docker-tools
-    needs: [test]
+    needs: [cargo-deny, clippy, fmt, test]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,3 +114,48 @@ jobs:
         with:
           name: plugin
           path: target/wasm32-wasi/release/wasm_oidc_plugin.wasm
+
+  docker-image:
+    needs: [cargo-deny, clippy, fmt, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: antonengelhardt/wasm-oidc-plugin:pr-${{ github.event.pull_request.head.ref}}
+
+  ghcr-image:
+    runs-on: ubuntu-latest
+    needs: [cargo-deny, clippy, fmt, test]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to GHCR
+        run: |
+          docker pull ghcr.io/antonengelhardt/wasm-oidc-plugin:pr-${{ github.event.pull_request.head.ref }} || true # Pull the image to cache
+          docker build -t ghcr.io/antonengelhardt/wasm-oidc-plugin:pr-${{ github.event.pull_request.head.ref }} .
+          docker push ghcr.io/antonengelhardt/wasm-oidc-plugin:pr-${{ github.event.pull_request.head.ref }}

--- a/demo/configmap.yml
+++ b/demo/configmap.yml
@@ -88,9 +88,8 @@ data:
                 - endpoint:
                     address:
                       socket_address:
-                        address: httpbin.org
+                        address: httpbin-service.wasm-oidc-plugin.svc.cluster.local
                         port_value: 80
-                    hostname: "httpbin.org"
       - name: oidc
         connect_timeout: 5s
         type: LOGICAL_DNS

--- a/demo/deployment-pre-built.yml
+++ b/demo/deployment-pre-built.yml
@@ -78,3 +78,33 @@ spec:
                 path: envoy.yaml
 
       restartPolicy: Always
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: wasm-oidc-plugin
+
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+
+  template:
+    metadata:
+      labels:
+        app: httpbin
+
+    spec:
+      containers:
+        - name: httpbin
+          image: kennethreitz/httpbin
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "250m"
+          ports:
+            - containerPort: 80

--- a/demo/hpa.yaml
+++ b/demo/hpa.yaml
@@ -1,7 +1,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: wasm-oidc-plugin
+  name: wasm-oidc-plugin-hpa
   namespace: wasm-oidc-plugin
 spec:
   minReplicas: 2
@@ -25,6 +25,48 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: wasm-oidc-plugin
+
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: httpbin-hpa
+  namespace: wasm-oidc-plugin
+spec:
+  minReplicas: 2
+  maxReplicas: 10
+
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 10
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+    scaleUp:
+      stabilizationWindowSeconds: 10
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 10
+
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: httpbin
 
   metrics:
     - type: Resource

--- a/demo/service.yml
+++ b/demo/service.yml
@@ -11,3 +11,17 @@ spec:
       targetPort: 10000
   selector:
     app: wasm-oidc-plugin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-service
+  namespace: wasm-oidc-plugin
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    app: httpbin

--- a/k8s/ci.yml
+++ b/k8s/ci.yml
@@ -1,4 +1,4 @@
-name: Test, Build and Deploy Wasm Plugin
+name: Test and Build wasm-oidc-plugin
 
 on:
   push:
@@ -9,8 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test
+  cargo-deny:
     runs-on: ubuntu-latest
     container:
       image: antonengelhardt/rust-docker-tools
@@ -18,24 +17,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run tests
-        run: |
-          rustc --version && cargo --version
-          cargo clippy
-          cargo test --workspace --verbose
+      - name: Rust version
+        run: rustc --version && cargo --version
 
       - name: Cargo Deny
         uses: EmbarkStudios/cargo-deny-action@v1
 
-  build:
-    name: Build
-    needs: test
+  clippy:
     runs-on: ubuntu-latest
     container:
       image: antonengelhardt/rust-docker-tools
@@ -43,19 +31,156 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build
+      - name: Set up cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rust version
+        run: rustc --version && cargo --version
+
+      - name: Clippy
+        run: |
+          rustc --version && cargo --version
+          cargo clippy --release --all-targets --target=wasm32-wasi
+
+  fmt:
+    runs-on: ubuntu-latest
+    container:
+      image: antonengelhardt/rust-docker-tools
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rust version
+        run: rustc --version && cargo --version
+
+      - name: Fmt
+        run: cargo fmt -- --check
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: antonengelhardt/rust-docker-tools
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rust version
+        run: rustc --version && cargo --version
+
+      - name: Test
+        run: cargo test --workspace
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/antonengelhardt/rust-docker-tools
+    needs: [cargo-deny, clippy, fmt, test]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build WASM OIDC Plugin
         run: |
           cargo build --target wasm32-wasi --release
 
-      - name: Archive production artifacts
+      - name: Upload plugin as artifact
         uses: actions/upload-artifact@v2
         with:
-          name: name-of-your-wasm-plugin.wasm #! Rename, if necessary
-          path: target/wasm32-wasi/release/name_of_your_wasm_plugin.wasm #! Rename, if necessary
+          name: plugin
+          path: target/wasm32-wasi/release/wasm_oidc_plugin.wasm
 
-  deploy:
-    name: Deploy
-    needs: build
+  docker-image:
+    name: Build and push Docker image
+    needs: [cargo-deny, clippy, fmt, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: antonengelhardt/wasm-oidc-plugin:latest #! Rename, if necessary
+
+  ghcr-image:
+    name: Build and push GHCR image
+    runs-on: ubuntu-latest
+    needs: [cargo-deny, clippy, fmt, test]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to GHCR
+        run: |
+          docker pull ghcr.io/antonengelhardt/wasm-oidc-plugin:latest # Pull the image to cache #! Rename, if necessary
+          docker build -t ghcr.io/antonengelhardt/wasm-oidc-plugin:latest . #! Rename, if necessary
+          docker push ghcr.io/antonengelhardt/wasm-oidc-plugin:latest #! Rename, if necessary
+
+  deploy-k8s:
+    name: Deploy to Kubernetes
+    needs: [docker-image, ghcr-image]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: rollout restart deployment wasm-oidc-plugin -n wasm-oidc-plugin #! Rename, if necessary
+
+  deploy-do:
+    name: Deploy to Kubernetes (DigitalOcean)
+    needs: [docker-image, ghcr-image]
     runs-on: ubuntu-latest
     steps:
       - name: Install Doctl


### PR DESCRIPTION
- bump checkout to `v4`
- use httpbin deployment as upstream for the envoy instead of the (externally) hosted (and sometimes slow) httbin.org
- create docker-images for every PR