### PR TITLE
bug: parse `issuer` as string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -849,18 +849,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1163,7 +1163,7 @@ name = "wasm-oidc-plugin"
 version = "0.4.4"
 dependencies = [
  "aes-gcm",
- "base64 0.22.0",
+ "base64 0.22.1",
  "jwt-simple",
  "log",
  "pkce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ proxy-wasm = "0.2.1"
 
 # json, yaml, url parsing
 url = { version = "2.5.0", features = ["serde"] }
-serde = { version = "1.0.199", features = ["derive"] }
+serde = { version = "1.0.200", features = ["derive"] }
 serde_yaml = "0.9.33"
 serde_json = "1.0.116"
 serde_urlencoded = "0.7.1"
 
 # base64
-base64 = "0.22.0"
+base64 = "0.22.1"
 
 # regex
 regex = "1.10.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ pub struct OpenIdConfig {
     /// The URL of the token endpoint
     pub token_endpoint: Url,
     /// The issuer that will be used for the token request
-    pub issuer: Url,
+    pub issuer: String,
 
     // Relevant for Validation of the ID Token
     /// The public keys that will be used for the validation of the ID Token

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -409,7 +409,7 @@ impl Context for OidcDiscovery {
                             open_id_config: Arc::new(OpenIdConfig {
                                 auth_endpoint: auth_endpoint.clone(),
                                 token_endpoint: token_endpoint.clone(),
-                                issuer: issuer.to_string(),
+                                issuer: issuer.clone(),
                                 public_keys: keys,
                             }),
                             plugin_config: plugin_config.clone(),

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -327,10 +327,7 @@ impl Context for OidcDiscovery {
 
                 // Parse the response body as json.
                 let body = match self.get_http_call_response_body(0, _body_size) {
-                    Some(body) => {
-                        debug!("openid config response body: {:?}", body);
-                        body
-                    }
+                    Some(body) => body,
                     None => {
                         warn!("no body in openid config response");
                         return;

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -86,7 +86,7 @@ pub enum OidcRootState {
         /// The token endpoint to exchange the code for a token
         token_endpoint: Url,
         /// The issuer
-        issuer: Url,
+        issuer: String,
         /// The url from which the public keys can be retrieved
         jwks_uri: Url,
     },
@@ -409,7 +409,7 @@ impl Context for OidcDiscovery {
                             open_id_config: Arc::new(OpenIdConfig {
                                 auth_endpoint: auth_endpoint.clone(),
                                 token_endpoint: token_endpoint.clone(),
-                                issuer: issuer.clone(),
+                                issuer: issuer.to_string(),
                                 public_keys: keys,
                             }),
                             plugin_config: plugin_config.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,13 +379,7 @@ impl ConfiguredOidc {
         // Define allowed issuers and audiences
         let mut allowed_issuers = HashSet::new();
         // remove last slash from issuer url
-        allowed_issuers.insert(
-            self.open_id_config
-                .issuer
-                .to_string()
-                .trim_end_matches('/')
-                .to_string(),
-        );
+        allowed_issuers.insert(self.open_id_config.issuer.to_string());
         let mut allowed_audiences = HashSet::new();
         allowed_audiences.insert(self.plugin_config.audience.to_string());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,7 @@ impl ConfiguredOidc {
         // Define allowed issuers and audiences
         let mut allowed_issuers = HashSet::new();
         // remove last slash from issuer url
-        allowed_issuers.insert(self.open_id_config.issuer.to_string());
+        allowed_issuers.insert(self.open_id_config.issuer.clone());
         let mut allowed_audiences = HashSet::new();
         allowed_audiences.insert(self.plugin_config.audience.to_string());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,8 +537,6 @@ impl ConfiguredOidc {
         // the body, so we can assume that the response is valid.
         match self.get_http_call_response_body(0, body_size) {
             Some(body) => {
-                debug!("token response: {:?}", body);
-
                 // Get nonce and cookie
                 let encoded_nonce = self.get_nonce()?;
                 let encoded_cookie = self.get_session_cookie_as_string()?;

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -22,7 +22,7 @@ use url::Url;
 #[derive(Deserialize, Debug)]
 pub struct OidcDiscoveryResponse {
     /// The issuer of the OpenID Connect Provider
-    pub issuer: Url,
+    pub issuer: String,
     /// The authorization endpoint to start the code flow
     pub authorization_endpoint: Url,
     /// The token endpoint to exchange the code for a token


### PR DESCRIPTION
some providers have a "/" at the end of the issuer in the openid config and some do not. we previously stripped any "/" characters away, but Auth0 is now signing tokens with a slash. in that case, the issuer was parsed with a slash that we then stirpped away resulting in a issuer mismatch.