### PR TITLE
feat(auth): logout route

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The plugin is configured via the `envoy.yaml`-file. The following configuration 
 | `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` | ❌ |
 | `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` | ❌ |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` | ✅ |
-| `logout_path` | `string` | The path, that is used to logout the user. | `/logout` | ✅ |
+| `logout_path` | `string` | The path, that is used to logout the user. The user will be redirected to `end_session_endpoint` of the OIDC provider, if the server supports this; alternatively the user is sent to "/" | `/logout` | ✅ |
 | `filter_plugin_cookies | `bool` | Whether to filter the cookies that are managed and controlled by the plugin (namely cookie_name and `nonce`). | `true` | ✅ |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` | ✅ |
 | `token_validation` | bool | Whether to validate the token or not. | `true` | ✅ |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The plugin is configured via the `envoy.yaml`-file. The following configuration 
 | `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` | ❌ |
 | `id_token_header_prefix` | `string` | The prefix of the header, that is used to forward the id token, if empty "" is used. | `Bearer ` | ❌ |
 | `cookie_name` | `string` | The name of the cookie, that is used to store the session. | `oidcSession` | ✅ |
+| `logout_path` | `string` | The path, that is used to logout the user. | `/logout` | ✅ |
 | `filter_plugin_cookies | `bool` | Whether to filter the cookies that are managed and controlled by the plugin (namely cookie_name and `nonce`). | `true` | ✅ |
 | `cookie_duration` | `u64` | The duration in seconds, after which the session cookie expires. | `86400` | ✅ |
 | `token_validation` | bool | Whether to validate the token or not. | `true` | ✅ |

--- a/demo/configmap.yml
+++ b/demo/configmap.yml
@@ -54,6 +54,7 @@ data:
                               id_token_header_prefix: "Bearer "
 
                               cookie_name: "oidcSession"
+                              logout_path: "/logout"
                               filter_plugin_cookies: true # or false
                               cookie_duration: 8640000 # in seconds
                               token_validation: true # or false

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -44,6 +44,7 @@ static_resources:
                           id_token_header_prefix: "Bearer "
 
                           cookie_name: "oidcSession" # max. 32 characters
+                          logout_path: "/logout"
                           filter_plugin_cookies: true # or false
                           cookie_duration: 86400 # in seconds
                           token_validation: true # or false

--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -55,6 +55,7 @@ data:
                               id_token_header_prefix: "Bearer "
 
                               cookie_name: "oidcSession"
+                              logout_path: "/logout"
                               cookie_duration: 86400 # in seconds
                               token_validation: true # or false
                               aes_key: "i-am-a-forty-four-characters-long-string-key" # generate with `openssl rand -base64 32`

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,8 @@ pub struct PluginConfiguration {
     // Cookie settings
     /// The cookie name that will be used for the session cookie
     pub cookie_name: String,
+    /// Logout path to clear all cookies
+    pub logout_path: String,
     /// Filter out the cookies created and controlled by the plugin
     /// If the value is true, the cookies will be filtered out
     pub filter_plugin_cookies: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct OpenIdConfig {
     // Everything relevant for the Token Exchange Flow
     /// The URL of the token endpoint
     pub token_endpoint: Url,
+    /// The URL to logout the user
+    pub end_session_endpoint: Option<Url>,
     /// The issuer that will be used for the token request
     pub issuer: String,
 
@@ -71,7 +73,7 @@ pub struct PluginConfiguration {
     // Cookie settings
     /// The cookie name that will be used for the session cookie
     pub cookie_name: String,
-    /// Logout path to clear all cookies
+    /// The URL to logout the user
     pub logout_path: String,
     /// Filter out the cookies created and controlled by the plugin
     /// If the value is true, the cookies will be filtered out

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -160,7 +160,7 @@ impl Session {
 
         // Parse cookie into a struct
         let state = serde_json::from_slice::<Session>(&decrypted_cookie)?;
-        debug!("state: {:?}", state);
+        debug!("auth_state: {:?}", state);
         Ok(state)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,27 @@ impl HttpContext for ConfiguredOidc {
             return Action::Pause;
         }
 
+        // If Path is login route, clear cookies and redirect to base path
+        if path == self.plugin_config.logout_path {
+            debug!("logout path hit, clearing cookies");
+
+            let cookies_values = Session::make_cookie_values(
+                "",
+                "",
+                &self.plugin_config.cookie_name,
+                0,
+                self.get_number_of_cookies() as u64,
+            );
+
+            let mut response_headers = Session::make_set_cookie_headers(&cookies_values);
+
+            response_headers.push(("Location", "/"));
+            response_headers.push(("Cache-Control", "no-cache"));
+
+            self.send_http_response(307, response_headers, Some(b"Logging out..."));
+            return Action::Pause;
+        }
+
         if self
             .plugin_config
             .exclude_hosts

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -27,6 +27,8 @@ pub struct OidcDiscoveryResponse {
     pub authorization_endpoint: Url,
     /// The token endpoint to exchange the code for a token
     pub token_endpoint: Url,
+    /// The URL to logout the user
+    pub end_session_endpoint: Option<Url>,
     /// The jwks uri to load the jwks response from
     pub jwks_uri: Url,
 }


### PR DESCRIPTION
Adds another Config option which clears the cookies that have been set by the plugin. 

- If the OIDC provider supports the `end_session_endpoint` the user will be redirected to this location. This clears all plugin and auth server cookies. The session will be fully terminated! 
- If the auth server does not support this, then the user will be redirected to `/`. In this case, the cookies from the auth server might still be set which automatically generates a new code. This results in a token reset and not in an actual logout.

OpenID Spec: https://arc.net/l/quote/inktedyu

Closes #94 