### PR TITLE
fix(exclude): get scheme to parse url, more debug logs and yaml fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The plugin is configured via the `envoy.yaml`-file. The following configuration 
 | `reload_interval_in_hours` | `u64` | The interval in hours, after which the OIDC configuration is reloaded. | `24` | ✅ |
 | `exclude_hosts` | `Vec<Regex>` | A comma separated list Hosts (in Regex expressions), that are excluded from the filter. | `["localhost:10000"]` | ❌ |
 | `exclude_paths` | `Vec<Regex>` | A comma separated list of paths (in Regex expressions), that are excluded from the filter. | `["/health"]` | ❌ |
-| `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["localhost:10000/health"]` | ❌ |
+| `exclude_urls` | `Vec<Regex>` | A comma separated list of URLs (in Regex expressions), that are excluded from the filter. | `["http://localhost:10000/health"]` | ❌ |
 | `access_token_header_name` | `string` | If set, this name will be used to forward the access token to the backend. | `X-Access-Token` | ❌ |
 | `access_token_header_prefix` | `string` | The prefix of the header, that is used to forward the access token, if empty "" is used. | `Bearer ` | ❌ |
 | `id_token_header_name` | `string` | If set, this name will be used to forward the id token to the backend. | `X-Id-Token` | ❌ |

--- a/demo/configmap.yml
+++ b/demo/configmap.yml
@@ -44,9 +44,12 @@ data:
                               config_endpoint: "https://demo-wasm-oidc-plugin.eu.auth0.com/.well-known/openid-configuration"
                               reload_interval_in_h: 1 # in hours
 
-                              exclude_hosts: [] # or ["httpbin.org"]
-                              exclude_paths: [] # or ["/favicon.ico"]
-                              exclude_urls: [] # or ["http://localhost:10000/#/HTTP_Methods/get_get"]
+                              exclude_hosts:
+                                # - "httpbin.org"
+                              exclude_paths:
+                                # - "/favicon.ico"
+                              exclude_urls:
+                                # - https://httpbin.org/favicon.ico
 
                               access_token_header_name: # or "Authorization"
                               access_token_header_prefix: "Bearer "

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -34,9 +34,12 @@ static_resources:
                           config_endpoint: "https://accounts.google.com/.well-known/openid-configuration"
                           reload_interval_in_h: 1 # in hours
 
-                          exclude_hosts: [] # or ["httpbin.org"]
-                          exclude_paths: [] # or ["/favicon.ico"]
-                          exclude_urls: [] # or ["http://localhost:10000/#/HTTP_Methods/get_get"]
+                          exclude_hosts:
+                            # - "httpbin.org"
+                          exclude_paths:
+                            # - "/favicon.ico"
+                          exclude_urls:
+                            # - https://httpbin.org/favicon.ico
 
                           access_token_header_name: # or "Authorization"
                           access_token_header_prefix: "Bearer "

--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -45,9 +45,12 @@ data:
                               config_endpoint: "https://accounts.google.com/.well-known/openid-configuration"
                               reload_interval_in_h: 1 # in hours
 
-                              exclude_hosts: [] # or ["httpbin.org"]
-                              exclude_paths: [] # or ["/favicon.ico"]
-                              exclude_urls: [] # or ["http://localhost:10000/#/HTTP_Methods/get_get"]
+                              exclude_hosts:
+                                # - "httpbin.org"
+                              exclude_paths:
+                                # - "/favicon.ico"
+                              exclude_urls:
+                                # - https://httpbin.org/favicon.ico
 
                               access_token_header_name: # or "Authorization"
                               access_token_header_prefix: "Bearer "

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,6 @@ struct ConfiguredOidc {
 impl HttpContext for ConfiguredOidc {
     /// This function is called when the request headers are received.
     fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
-
         // Get the host, path and scheme from the request headers
         let host = self.get_host().unwrap_or_default();
         debug!("host: {}", host);


### PR DESCRIPTION
the url needs the `:scheme` header to be parsed fully. 

added one comment back which got lost while [rebasing](https://github.com/antonengelhardt/wasm-oidc-plugin/commit/02ab7b0dcb6f0d409494e09b9eb7676bb5440f0f)... 

we should write tests for this when finishing #15 