### PR TITLE
refactor: `wasm32-wasi` renamed to `wasm32-wasip1`, chore(deps); rust to 1.78

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: rustc --version && cargo --version
 
       - name: Clippy
-        run: cargo clippy --release --all-targets --target=wasm32-wasi -- -D warnings
+        run: cargo clippy --release --all-targets --target=wasm32-wasip1 -- -D warnings
 
   fmt:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
 
       - name: Build wasm-oidc-plugin
         run: |
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
 
       - name: Upload plugin as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Clippy
         run: |
           rustc --version && cargo --version
-          cargo clippy --release --all-targets --target=wasm32-wasi -- -D warnings
+          cargo clippy --release --all-targets --target=wasm32-wasip1 -- -D warnings
 
   fmt:
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
 
       - name: Build wasm-oidc-plugin
         run: |
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
 
       - name: Upload plugin as artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM rust:1.75.0 AS builder
+FROM rust:1.78.0 AS builder
 
 COPY src/ src/
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 
-RUN rustup target add wasm32-wasi
+RUN rustup target add wasm32-wasip1
 
-RUN cargo build --target=wasm32-wasi --release
+RUN cargo build --target=wasm32-wasip1 --release
 
 ##################################################
 
 FROM envoyproxy/envoy:v1.29-latest
 
-COPY --from=builder /target/wasm32-wasi/release/wasm_oidc_plugin.wasm /etc/envoy/proxy-wasm-plugins/wasm_oidc_plugin.wasm
+COPY --from=builder /target/wasm32-wasip1/release/wasm_oidc_plugin.wasm /etc/envoy/proxy-wasm-plugins/wasm_oidc_plugin.wasm
 
 CMD [ "envoy", "-c", "/etc/envoy/envoy.yaml" ]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 build:
-	cargo build --target wasm32-wasi --release
+	cargo build --target wasm32-wasip1 --release
 run:
-	cargo build --target wasm32-wasi --release
+	cargo build --target wasm32-wasip1 --release
 	docker-compose up
 run-background:
-	cargo build --target wasm32-wasi --release
+	cargo build --target wasm32-wasip1 --release
 	docker-compose up -d
 docker-image:
 	docker buildx build --platform linux/amd64 -f Dockerfile -t antonengelhardt/wasm-oidc-plugin:latest .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "10000:10000"
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
-      - ./target/wasm32-wasi/release:/etc/envoy/proxy-wasm-plugins
+      - ./target/wasm32-wasip1/release:/etc/envoy/proxy-wasm-plugins
     networks:
       - envoymesh
     # Additional options:

--- a/k8s/ci.yml
+++ b/k8s/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build wasm-oidc-plugin
         run: |
-          cargo build --target wasm32-wasi --release
+          cargo build --target wasm32-wasip1 --release
 
       - name: Upload plugin as artifact
         uses: actions/upload-artifact@v4

--- a/k8s/deployment-init-container.yaml
+++ b/k8s/deployment-init-container.yaml
@@ -36,7 +36,7 @@ spec:
               apk add git
               git clone -b main https://${GITHUB_PAT}@github.com/your-org/your-repo.git #! Change URL and branch
               cd your-repo #! Change directory
-              cargo build --target wasm32-wasi --release
+              cargo build --target wasm32-wasip1 --release
               cp target/wasm32-wasi/release/name_of_your_wasm_plugin.wasm /plugins/name_of_your_wasm_plugin.wasm #! Rename, if necessary
 
           env:


### PR DESCRIPTION
## Please describe your changes and why you made them

- Rename `wasm32-wasi` to `wasm32-wasip1`
- Bump Rust base image from 1.75 to 1.78

## Does this PR introduce a breaking change?

<!-- Uncomment one of the following -->

🚀 This PR does **not** introduce a breaking change

## Other information and Screenshots (if appropriate)

https://github.com/proxy-wasm/proxy-wasm-rust-sdk/pull/277

https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html

Cherry picked commit from #99 (9c4c076297d0ceffa97637da57bf8872cd7de82c)