### PR TITLE
feat: optional access rules for OIDC ID token claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The plugin is configured via the `envoy.yaml`-file. The following configuration 
 | `filter_plugin_cookies`      | `bool`              | Whether to filter the cookies that are managed and controlled by the plugin (namely cookie_name and `nonce`).                                                                             | `true`                              | ✅       |
 | `cookie_duration_in_s`       | `u64`               | The duration in seconds, after which the session cookie expires.                                                                                                                          | `86400`                             | ✅       |
 | `token_validation`           | bool                | Whether to validate the token or not.                                                                                                                                                     | `true`                              | ✅       |
+| `access_rules`               | `Vec<String>`       | Optional access rules evaluated against ID token claims. Any matching rule grants access; see [Access rules](#access-rules).                                                              | See below                           | ❌       |
 | `aes_key`                    | `string`            | A base64 encoded AES-256 Key: `openssl rand -base64 32`                                                                                                                                   | `<generated-aes-key>`               | ✅       |
 | `reload_interval_in_h`       | `u64`               | The interval in hours, after which the OpenID configuration is reloaded.                                                                                                                  | `24`                                | ✅       |
 | `ticking_interval_in_ms`     | `u64`               | The interval in milliseconds, after which the plugin will wait for the discovery endpoint to respond or send a new request.                                                               | `500`                               | ✅       |
@@ -139,6 +140,25 @@ claims:
   id_token:
     groups: null
     username: null
+```
+
+#### Access rules
+
+Optional rules restrict which authenticated users may reach the upstream. If `access_rules` is omitted or empty, every successfully authenticated user is allowed.
+
+- **OR** across list entries — one matching rule is enough
+- **AND** within a rule using `&`
+- `claim==value` — exact match; for JSON array claims (e.g. `groups`), true if any element equals `value`
+- `claim=~regex` — regex match against a string claim, or any array element
+- Claim names are ID token fields (`email`, `groups`, `sub`, …)
+- Invalid rules fail plugin configuration at load time
+
+If authentication succeeds but no rule matches, the plugin returns **403** with an error page explaining that authentication succeeded but access was denied, and that an administrator should be contacted.
+
+```yaml
+access_rules:
+  - "email==admin@company.com"
+  - "email=~.*@company\\.com$ & groups==admins"
 ```
 
 ### Migrating from the legacy single-provider config

--- a/demo/configmap.yml
+++ b/demo/configmap.yml
@@ -58,6 +58,10 @@ data:
                               filter_plugin_cookies: true # or false
                               cookie_duration_in_s: 8640000
                               token_validation: true
+                              # Optional: restrict access by ID token claims (OR across rules, AND with &)
+                              # access_rules:
+                              #   - "email==admin@company.com"
+                              #   - "email=~.*@company\\.com$ & groups==admins"
                               aes_key: "redacted"
 
                               reload_interval_in_h: 1

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -48,6 +48,10 @@ static_resources:
                           filter_plugin_cookies: true # or false
                           cookie_duration_in_s: 8640000 # in seconds
                           token_validation: true # or false
+                          # Optional: restrict access by ID token claims (OR across rules, AND with &)
+                          # access_rules:
+                          #   - "email==admin@company.com"
+                          #   - "email=~.*@company\\.com$ & groups==admins"
                           aes_key: "i-am-a-forty-four-characters-long-string-key" # generate with `openssl rand -base64 32`
 
                           reload_interval_in_h: 1 # in hours

--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -58,6 +58,10 @@ data:
                               logout_path: "/logout"
                               cookie_duration_in_s: 8640000 # in seconds
                               token_validation: true # or false
+                              # Optional: restrict access by ID token claims (OR across rules, AND with &)
+                              # access_rules:
+                              #   - "email==admin@company.com"
+                              #   - "email=~.*@company\\.com$ & groups==admins"
                               aes_key: "i-am-a-forty-four-characters-long-string-key" # generate with `openssl rand -base64 32`
 
                               reload_interval_in_h: 1 # in hours

--- a/src/access.rs
+++ b/src/access.rs
@@ -1,0 +1,351 @@
+//! Optional access rules evaluated against OpenID ID token claims.
+//!
+//! Rules are configured as strings. Any matching rule grants access (OR).
+//! Conditions within a single rule are AND'd with `&`.
+//!
+//! Supported condition operators:
+//! * `claim==value` — exact match (arrays match if any element equals `value`)
+//! * `claim=~regex` — regex match against a string claim, or any array element
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD as base64engine_urlsafe, Engine as _};
+use regex::Regex;
+use serde_json::{Map, Value};
+
+use crate::error::PluginError;
+
+/// A single condition comparing one claim to an expected value or pattern.
+#[derive(Debug, Clone)]
+pub enum Condition {
+    /// Exact equality (`claim==value`).
+    Equals { claim: String, value: String },
+    /// Regex match (`claim=~pattern`).
+    Matches { claim: String, regex: Regex },
+}
+
+/// One access rule: all conditions must match (AND).
+#[derive(Debug, Clone)]
+pub struct AccessRule {
+    pub conditions: Vec<Condition>,
+}
+
+impl AccessRule {
+    /// Parse a rule string such as `email==a@b.com & groups==admins`.
+    pub fn parse(rule: &str) -> Result<Self, PluginError> {
+        let trimmed = rule.trim();
+        if trimmed.is_empty() {
+            return Err(PluginError::AccessRuleParseError(
+                "access rule must not be empty".to_string(),
+            ));
+        }
+
+        let mut conditions = Vec::new();
+        for part in trimmed.split('&') {
+            let part = part.trim();
+            if part.is_empty() {
+                return Err(PluginError::AccessRuleParseError(format!(
+                    "empty condition in access rule: {rule}"
+                )));
+            }
+            conditions.push(Condition::parse(part)?);
+        }
+
+        Ok(AccessRule { conditions })
+    }
+
+    /// Returns true if every condition matches the given claims.
+    pub fn matches(&self, claims: &Map<String, Value>) -> bool {
+        self.conditions.iter().all(|c| c.matches(claims))
+    }
+}
+
+impl Condition {
+    /// Parse a single condition (`claim==value` or `claim=~regex`).
+    pub fn parse(condition: &str) -> Result<Self, PluginError> {
+        match find_operator(condition) {
+            Some((claim, "==", value)) => {
+                if claim.is_empty() || value.is_empty() {
+                    return Err(PluginError::AccessRuleParseError(format!(
+                        "invalid equals condition: {condition}"
+                    )));
+                }
+                Ok(Condition::Equals {
+                    claim: claim.to_string(),
+                    value: value.to_string(),
+                })
+            }
+            Some((claim, "=~", pattern)) => {
+                if claim.is_empty() || pattern.is_empty() {
+                    return Err(PluginError::AccessRuleParseError(format!(
+                        "invalid matches condition: {condition}"
+                    )));
+                }
+                let regex = Regex::new(pattern).map_err(|e| {
+                    PluginError::AccessRuleParseError(format!(
+                        "invalid regex in access rule `{condition}`: {e}"
+                    ))
+                })?;
+                Ok(Condition::Matches {
+                    claim: claim.to_string(),
+                    regex,
+                })
+            }
+            _ => Err(PluginError::AccessRuleParseError(format!(
+                "access condition must use `==` or `=~`: {condition}"
+            ))),
+        }
+    }
+
+    /// Returns true if this condition matches the given claims.
+    pub fn matches(&self, claims: &Map<String, Value>) -> bool {
+        match self {
+            Condition::Equals { claim, value } => match claims.get(claim) {
+                Some(Value::String(s)) => s == value,
+                Some(Value::Number(n)) => n.to_string() == *value,
+                Some(Value::Bool(b)) => b.to_string() == *value,
+                Some(Value::Array(arr)) => arr.iter().any(|item| match item {
+                    Value::String(s) => s == value,
+                    Value::Number(n) => n.to_string() == *value,
+                    Value::Bool(b) => b.to_string() == *value,
+                    _ => false,
+                }),
+                _ => false,
+            },
+            Condition::Matches { claim, regex } => match claims.get(claim) {
+                Some(Value::String(s)) => regex.is_match(s),
+                Some(Value::Number(n)) => regex.is_match(&n.to_string()),
+                Some(Value::Bool(b)) => regex.is_match(&b.to_string()),
+                Some(Value::Array(arr)) => arr.iter().any(|item| match item {
+                    Value::String(s) => regex.is_match(s),
+                    Value::Number(n) => regex.is_match(&n.to_string()),
+                    Value::Bool(b) => regex.is_match(&b.to_string()),
+                    _ => false,
+                }),
+                _ => false,
+            },
+        }
+    }
+}
+
+/// Find the first `==` or `=~` operator in `input` and split around it.
+fn find_operator(input: &str) -> Option<(&str, &str, &str)> {
+    let eq = input.find("==");
+    let re = input.find("=~");
+    match (eq, re) {
+        (Some(i), Some(j)) if i <= j => Some((input[..i].trim(), "==", input[i + 2..].trim())),
+        (Some(i), None) => Some((input[..i].trim(), "==", input[i + 2..].trim())),
+        (None, Some(j)) | (Some(_), Some(j)) => {
+            Some((input[..j].trim(), "=~", input[j + 2..].trim()))
+        }
+        (None, None) => None,
+    }
+}
+
+/// Parse a list of rule strings into compiled [`AccessRule`]s.
+pub fn parse_rules(rules: &[String]) -> Result<Vec<AccessRule>, PluginError> {
+    rules.iter().map(|r| AccessRule::parse(r)).collect()
+}
+
+/// Returns true if `rules` is empty or any rule matches `claims`.
+pub fn evaluate(rules: &[AccessRule], claims: &Map<String, Value>) -> bool {
+    if rules.is_empty() {
+        return true;
+    }
+    rules.iter().any(|rule| rule.matches(claims))
+}
+
+/// Decode the JWT payload (middle segment) into a JSON object of claims.
+///
+/// Does not verify the signature — callers must already trust the token
+/// (e.g. after JWT validation or because it came from the encrypted session).
+pub fn decode_jwt_claims(token: &str) -> Result<Map<String, Value>, PluginError> {
+    let mut parts = token.split('.');
+    let _header = parts.next().ok_or_else(|| {
+        PluginError::AccessRuleParseError("id token is not a valid JWT".to_string())
+    })?;
+    let payload = parts.next().ok_or_else(|| {
+        PluginError::AccessRuleParseError("id token is not a valid JWT".to_string())
+    })?;
+
+    let decoded = base64engine_urlsafe.decode(payload.as_bytes())?;
+
+    let value: Value = serde_json::from_slice(&decoded)?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Err(PluginError::AccessRuleParseError(
+            "id token payload is not a JSON object".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn claims(value: Value) -> Map<String, Value> {
+        value.as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn parse_equals_condition() {
+        let rule = AccessRule::parse("email==admin@company.com").unwrap();
+        assert_eq!(rule.conditions.len(), 1);
+        match &rule.conditions[0] {
+            Condition::Equals { claim, value } => {
+                assert_eq!(claim, "email");
+                assert_eq!(value, "admin@company.com");
+            }
+            _ => panic!("expected Equals"),
+        }
+    }
+
+    #[test]
+    fn parse_matches_condition() {
+        let rule = AccessRule::parse(r"email=~.*@company\.com$").unwrap();
+        match &rule.conditions[0] {
+            Condition::Matches { claim, regex } => {
+                assert_eq!(claim, "email");
+                assert!(regex.is_match("user@company.com"));
+            }
+            _ => panic!("expected Matches"),
+        }
+    }
+
+    #[test]
+    fn parse_and_conditions() {
+        let rule = AccessRule::parse("email==a@b.com & groups==admins").unwrap();
+        assert_eq!(rule.conditions.len(), 2);
+    }
+
+    #[test]
+    fn parse_trims_whitespace() {
+        let rule = AccessRule::parse("  email == a@b.com  &  groups == admins  ").unwrap();
+        assert_eq!(rule.conditions.len(), 2);
+        match &rule.conditions[0] {
+            Condition::Equals { claim, value } => {
+                assert_eq!(claim, "email");
+                assert_eq!(value, "a@b.com");
+            }
+            _ => panic!("expected Equals"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_empty_rule() {
+        assert!(AccessRule::parse("").is_err());
+        assert!(AccessRule::parse("   ").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_missing_operator() {
+        assert!(AccessRule::parse("email").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_invalid_regex() {
+        assert!(AccessRule::parse("email=~[").is_err());
+    }
+
+    #[test]
+    fn evaluate_or_across_rules() {
+        let rules = parse_rules(&[
+            "email==admin@company.com".to_string(),
+            "groups==admins".to_string(),
+        ])
+        .unwrap();
+        let c = claims(json!({"email": "other@company.com", "groups": ["admins"]}));
+        assert!(evaluate(&rules, &c));
+    }
+
+    #[test]
+    fn evaluate_and_within_rule() {
+        let rules = parse_rules(&["email==user@company.com & groups==admins".to_string()]).unwrap();
+        let ok = claims(json!({"email": "user@company.com", "groups": ["admins", "users"]}));
+        let bad = claims(json!({"email": "user@company.com", "groups": ["users"]}));
+        assert!(evaluate(&rules, &ok));
+        assert!(!evaluate(&rules, &bad));
+    }
+
+    #[test]
+    fn evaluate_string_equals() {
+        let rules = parse_rules(&["email==admin@company.com".to_string()]).unwrap();
+        let ok = claims(json!({"email": "admin@company.com"}));
+        let bad = claims(json!({"email": "other@company.com"}));
+        assert!(evaluate(&rules, &ok));
+        assert!(!evaluate(&rules, &bad));
+    }
+
+    #[test]
+    fn evaluate_array_contains() {
+        let rules = parse_rules(&["groups==admins".to_string()]).unwrap();
+        let ok = claims(json!({"groups": ["users", "admins"]}));
+        let bad = claims(json!({"groups": ["users"]}));
+        assert!(evaluate(&rules, &ok));
+        assert!(!evaluate(&rules, &bad));
+    }
+
+    #[test]
+    fn evaluate_regex_on_string_and_array() {
+        let rules = parse_rules(&[r"email=~.*@company\.com$".to_string()]).unwrap();
+        assert!(evaluate(
+            &rules,
+            &claims(json!({"email": "user@company.com"}))
+        ));
+        assert!(!evaluate(
+            &rules,
+            &claims(json!({"email": "user@other.com"}))
+        ));
+
+        let group_rules = parse_rules(&[r"groups=~^admin".to_string()]).unwrap();
+        assert!(evaluate(
+            &group_rules,
+            &claims(json!({"groups": ["admins", "users"]}))
+        ));
+        assert!(!evaluate(
+            &group_rules,
+            &claims(json!({"groups": ["users"]}))
+        ));
+    }
+
+    #[test]
+    fn evaluate_missing_claim_denies() {
+        let rules = parse_rules(&["email==admin@company.com".to_string()]).unwrap();
+        let c = claims(json!({"sub": "123"}));
+        assert!(!evaluate(&rules, &c));
+    }
+
+    #[test]
+    fn evaluate_empty_rules_allows() {
+        let c = claims(json!({}));
+        assert!(evaluate(&[], &c));
+    }
+
+    #[test]
+    fn decode_jwt_claims_extracts_payload() {
+        // {"email":"a@b.com","groups":["admins"]}
+        let payload = base64engine_urlsafe.encode(br#"{"email":"a@b.com","groups":["admins"]}"#);
+        let token = format!("e30.{payload}.sig");
+        let map = decode_jwt_claims(&token).unwrap();
+        assert_eq!(map.get("email").unwrap().as_str().unwrap(), "a@b.com");
+        assert!(map.get("groups").unwrap().as_array().unwrap().len() == 1);
+    }
+
+    #[test]
+    fn decode_jwt_claims_rejects_invalid_token() {
+        assert!(decode_jwt_claims("not-a-jwt").is_err());
+        assert!(decode_jwt_claims("").is_err());
+        assert!(decode_jwt_claims("aaa.!!!notbase64!!!").is_err());
+    }
+
+    #[test]
+    fn parse_prefers_first_operator() {
+        let rule = AccessRule::parse(r"email=~a==b").unwrap();
+        match &rule.conditions[0] {
+            Condition::Matches { claim, regex } => {
+                assert_eq!(claim, "email");
+                assert!(regex.is_match("a==b"));
+            }
+            _ => panic!("expected Matches when =~ appears first"),
+        }
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -21,6 +21,7 @@ use proxy_wasm::types::*;
 // url
 use url::{form_urlencoded, Url};
 
+use crate::access;
 use crate::config::V2PluginConfiguration;
 use crate::discovery::OpenIdProvider;
 use crate::error::PluginError;
@@ -147,6 +148,36 @@ impl HttpContext for OidcHttpContext {
                 }
             },
             Ok(auth_state) => {
+                // Enforce optional access rules against ID token claims
+                if let Err(e) = self.check_access(&auth_state) {
+                    match e {
+                        PluginError::AccessDenied => {
+                            warn!(
+                                "access denied by access rules for request {}",
+                                self.request_id
+                            );
+                            self.show_error_page(
+                                403,
+                                "Access denied",
+                                "Authentication was successful, but you do not have access to this application. Please contact your administrator.",
+                            );
+                            return Action::Pause;
+                        }
+                        _ => {
+                            warn!(
+                                "access rule evaluation failed for request {} with error: {}",
+                                self.request_id, e
+                            );
+                            self.show_error_page(
+                                503,
+                                "Access check failed",
+                                "Please try again, delete your cookies or contact your system administrator with the request id!",
+                            );
+                            return Action::Pause;
+                        }
+                    }
+                }
+
                 // Append headers
                 self.append_headers(&auth_state);
                 // Filter proxy cookies
@@ -194,6 +225,27 @@ impl Context for OidcHttpContext {
 
 /// Helper functions for the `OidcHttpContext`` struct.
 impl OidcHttpContext {
+    /// Check optional access rules against the ID token claims.
+    ///
+    /// If `access_rules` is empty, access is granted. Otherwise the ID token
+    /// payload is decoded and evaluated: any matching rule grants access.
+    fn check_access(&self, auth_state: &AuthorizationState) -> Result<(), PluginError> {
+        if self.plugin_config.access_rules.is_empty() {
+            return Ok(());
+        }
+
+        // Rules were validated at config load; re-parse for evaluation.
+        let rules = access::parse_rules(&self.plugin_config.access_rules)?;
+        let claims = access::decode_jwt_claims(&auth_state.id_token)?;
+
+        if access::evaluate(&rules, &claims) {
+            debug!("access rules matched, granting access");
+            Ok(())
+        } else {
+            Err(PluginError::AccessDenied)
+        }
+    }
+
     /// Check if the request is excluded.
     ///
     /// ## Arguments

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,12 @@ pub struct V2PluginConfiguration {
     pub cookie_duration_in_s: u64,
     /// Option to skip Token Validation
     pub token_validation: bool,
+    /// Optional access rules evaluated against ID token claims.
+    /// Any matching rule grants access; conditions within a rule are AND'd with `&`.
+    /// Example: `email==admin@company.com` or `email=~.*@company\\.com$ & groups==admins`
+    /// If omitted or empty, all authenticated users are allowed.
+    #[serde(default)]
+    pub access_rules: Vec<String>,
     /// AES Key
     #[serde(deserialize_with = "deserialize_aes_key")]
     pub aes_key: Secret<Aes256Gcm>,
@@ -116,6 +122,9 @@ impl V2PluginConfiguration {
             "`logout_path` does not start with a `/`"
         );
         ensure!(self.cookie_duration_in_s > 0, "`cookie_duration_in_s` is 0");
+
+        // Validate access rules parse correctly
+        crate::access::parse_rules(&self.access_rules).map_err(|e| anyhow::anyhow!("{e}"))?;
 
         for provider in &self.open_id_configs {
             ensure!(!provider.authority.is_empty(), "`authority` is empty");
@@ -278,6 +287,7 @@ impl V1PluginConfiguration {
             filter_plugin_cookies: self.filter_plugin_cookies,
             cookie_duration_in_s: self.cookie_duration,
             token_validation: self.token_validation,
+            access_rules: vec![],
             aes_key: self.aes_key,
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,12 @@ pub enum PluginError {
     AuthorizationStateNotFoundError,
     #[error("state does not match")]
     StateMismatchError,
+
+    // Access control errors
+    #[error("invalid access rule: {0}")]
+    AccessRuleParseError(String),
+    #[error("access denied by access rules")]
+    AccessDenied,
 }
 
 impl OidcHttpContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+/// This module contains optional access rules evaluated against ID token claims
+mod access;
+
 /// This module contains all functions, calls and callbacks to execute the OpenID Authorization Code Flow
 mod auth;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `access_rules` so admins can restrict who reaches the upstream after successful OIDC authentication. Rules evaluate ID token claims (e.g. `email`, `groups`).

Implements #77.

### Rule syntax

```yaml
access_rules:
  - "email==admin@company.com"
  - "email=~.*@company\\.com$ & groups==admins"
```

- **OR** across list entries (one match grants access)
- **AND** within a rule via `&`
- `claim==value` for exact match (arrays: containment)
- `claim=~regex` for regex match
- Omitted/empty → all authenticated users allowed (unchanged behavior)

### Denial UX

When authentication succeeds but no rule matches, the plugin returns **403** with the existing error page: authentication was successful, but access was denied — contact an administrator. Session cookies are kept; users can still use logout.

### Changes

- New `src/access.rs` with parse/evaluate/JWT claim decode + unit tests
- `access_rules` on `V2PluginConfiguration` (validated at config load)
- Evaluation hook after successful cookie validation in `auth.rs`
- README + commented examples in `envoy.yaml` / k8s / demo configs

## Testing

- `cargo test --workspace --lib` — 19 passed
- `cargo clippy --release --all-targets --target=wasm32-wasip1 -- -D warnings`
- `cargo build --target wasm32-wasip1 --release`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc2c1-60a8-7e26-a149-a78edb57068a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc2c1-60a8-7e26-a149-a78edb57068a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional claim-based authorization after successful OIDC authentication.
- Introduces parsing and evaluation for exact-match and regular-expression rules over ID-token claims.
- Validates access-rule syntax during configuration loading.
- Returns a dedicated 403 response when authenticated users do not match any configured rule.
- Documents the feature in the README and sample configurations.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking limitation that access policies cannot contain ampersands in claim values or regular expressions.

The authorization flow preserves logout and callback handling and applies rules on authenticated upstream requests, but unconditional ampersand splitting unnecessarily rejects otherwise valid policy values and patterns.

**Files Needing Attention:** src/access.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/access.rs | Adds claim-rule parsing, JWT payload decoding, evaluation, and unit tests; delimiter parsing cannot represent values or regexes containing ampersands. |
| src/auth.rs | Enforces configured rules after successful cookie validation while preserving earlier handling for exclusions, callbacks, and logout. |
| src/config.rs | Adds default-empty access-rule configuration and validates rule syntax during plugin configuration loading. |
| src/error.rs | Adds distinct errors for invalid rule syntax and access denial. |
| README.md | Documents rule semantics, configuration examples, and denial behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request] --> B{Excluded, health, logout, or callback?}
    B -->|Yes| C[Existing route handling]
    B -->|No| D[Validate encrypted session cookie]
    D -->|Invalid| E[Start OIDC authentication]
    D -->|Valid| F{Access rules configured?}
    F -->|No| G[Forward request upstream]
    F -->|Yes| H[Decode ID-token claims]
    H --> I{Any rule matches?}
    I -->|Yes| G
    I -->|No| J[Return 403 access denied]
    H -->|Decode error| K[Return 503 access-check failure]
```

<sub>Reviews (1): Last reviewed commit: ["feat: add optional access rules for ID t..."](https://github.com/antonengelhardt/wasm-oidc-plugin/commit/db7442fd78b5f667b971a308b0401c086a5642c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50048824)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->