### PR TITLE
fix: Make Performance Scripts Available

### DIFF
--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Performance testing script for wasm-oidc-plugin
+# Usage: ./scripts/performance.sh <endpoint> [num_requests]
+
+ENDPOINT="${1:-http://localhost:10000}"
+NUM_REQUESTS="${2:-1000}"
+
+echo "Running performance test against $ENDPOINT with $NUM_REQUESTS requests..."
+
+START_TIME=$(date +%s%N)
+for i in $(seq 1 "$NUM_REQUESTS"); do
+  curl -s -o /dev/null "$ENDPOINT" || true
+done
+END_TIME=$(date +%s%N)
+
+ELAPSED=$(( (END_TIME - START_TIME) / 1000000 ))
+echo "Completed $NUM_REQUESTS requests in ${ELAPSED}ms"
+THROUGHPUT=$(awk "BEGIN {printf \"%.2f\", $NUM_REQUESTS / ($ELAPSED / 1000)}")
+echo "Throughput: $THROUGHPUT req/s"


### PR DESCRIPTION
Closes #34

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a standalone shell script for sending sequential requests to an endpoint and reporting elapsed time and throughput.
- Adds configurable endpoint and request-count arguments with localhost defaults.
- Measures elapsed time around repeated curl calls.
- Calculates and prints aggregate request throughput.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the script is executable as documented and stops reporting failed requests as successful benchmark throughput.

The newly added script cannot be launched through its own documented command after checkout, and its unconditional failure suppression can produce convincing throughput numbers when the target service receives no requests.

**Files Needing Attention:** scripts/performance.sh

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/performance.sh | Adds the performance utility, but its documented direct invocation is blocked by file permissions and failed requests are counted as successful throughput. |

<sub>Reviews (1): Last reviewed commit: ["Add performance scripts"](https://github.com/antonengelhardt/wasm-oidc-plugin/commit/f1c25dd6460f2ab21be192714fe6066f7fae3e72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51650804)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->