### PR TITLE
Remove cluster rollout from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Test, Build and Deploy wasm-oidc-plugin
+name: Test and Build wasm-oidc-plugin
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,27 +86,6 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/antonengelhardt/wasm-oidc-plugin:latest
           cache-to: type=inline
 
-  deploy-demo:
-    needs: ghcr-image
-    environment: demo
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: |
-            rollout restart deployment wasm-oidc-plugin -n wasm-oidc-plugin
-
-      - name: Wait for deployment to be ready
-        uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: |
-            rollout status deployment wasm-oidc-plugin -n wasm-oidc-plugin --timeout=300s
-
   # changelog-and-release:
   #   runs-on: ubuntu-latest
   #   permissions:


### PR DESCRIPTION
## Summary
- Drop `kubectl rollout` / `KUBE_CONFIG` from GitHub Actions. CI only builds and pushes the image.
- ae-k8s-04 Flux image automation watches GHCR and commits `tag@digest` so pods roll there.


## After merge
Delete the unused Actions secret:

```bash
gh secret delete KUBE_CONFIG -R antonengelhardt/wasm-oidc-plugin
```

## Test plan
- [ ] Workflow still builds and pushes on merge to the default branch
- [ ] No remaining `kubectl` / `KUBE_CONFIG` references in `.github/workflows`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes direct Kubernetes deployment control from the build workflow, leaving CI responsible only for building and publishing the image.
- Removes the `deploy-demo` job and its rollout readiness wait.
- Eliminates workflow access to `KUBE_CONFIG`.
- Leaves the existing GHCR image build and push unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it cleanly removes the direct rollout path without disrupting the image build and push workflow.

No concrete defect or repository-rule violation was identified; deployment responsibility is intentionally transferred to the described external Flux automation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Removes the demo-cluster rollout job and Kubernetes secret usage while preserving image publication. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Merge to main] --> B[Build and test]
  B --> C[Push latest image to GHCR]
  C --> D[External Flux image automation]
  D --> E[Commit tag and digest update]
  E --> F[Kubernetes rollout]
```

<sub>Reviews (1): Last reviewed commit: ["Stop rolling out from Actions; Flux on a..."](https://github.com/antonengelhardt/wasm-oidc-plugin/commit/3e290e14948d8b6ea4f1082c556c48b092755309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60727839)</sub>

<!-- /greptile_comment -->