### PR TITLE
Rename live demo host to wasm-oidc-plugin.ae02.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Wasm-plugin for the [Envoy-Proxy](https://www.envoyproxy.io/) written in [Rust
 
 ## Demo
 
-Go to [demo-page](https://demo.wasm-oidc-plugin.ae02.de) to see the plugin in action. [Auth0](https://auth0.com) is used as the OpenID provider. Simply create an account or login with Google. The plugin has been configured to show [httpbin.org](https://httpbin.org) as the upstream. Then open the developer tools and check the cookies or use the [httpbin cookie inspector](https://demo.wasm-oidc-plugin.ae02.de/#/Cookies/get_cookies). You will see a cookie called `oidcSession-0`. This is the session, that holds the authorization state. If you delete the cookie and refresh the page, you will be redirected to the `authorization_endpoint` to authenticate again.
+Go to [demo-page](https://wasm-oidc-plugin.ae02.de) to see the plugin in action. [Auth0](https://auth0.com) is used as the OpenID provider. Simply create an account or login with Google. The plugin has been configured to show [httpbin.org](https://httpbin.org) as the upstream. Then open the developer tools and check the cookies or use the [httpbin cookie inspector](https://wasm-oidc-plugin.ae02.de/#/Cookies/get_cookies). You will see a cookie called `oidcSession-0`. This is the session, that holds the authorization state. If you delete the cookie and refresh the page, you will be redirected to the `authorization_endpoint` to authenticate again.
 
 ## Why this repo?
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,3 +1,3 @@
 # Demo for wasm-oidc-plugin
 
-[Try it yourself](https://demo.wasm-oidc-plugin.ae02.de)
+[Try it yourself](https://wasm-oidc-plugin.ae02.de)

--- a/demo/certificate-production.yml
+++ b/demo/certificate-production.yml
@@ -8,6 +8,6 @@ spec:
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: demo.wasm-oidc-plugin.ae02.de
+  commonName: wasm-oidc-plugin.ae02.de
   dnsNames:
-    - demo.wasm-oidc-plugin.ae02.de
+    - wasm-oidc-plugin.ae02.de

--- a/demo/configmap.yml
+++ b/demo/configmap.yml
@@ -68,7 +68,7 @@ data:
                                   config_endpoint: "https://demo-wasm-oidc-plugin.eu.auth0.com/.well-known/openid-configuration"
                                   upstream_cluster: "auth0"
                                   authority: "demo-wasm-oidc-plugin.eu.auth0.com"
-                                  redirect_uri: "https://demo.wasm-oidc-plugin.ae02.de/oidc/callback"
+                                  redirect_uri: "https://wasm-oidc-plugin.ae02.de/oidc/callback"
                                   client_id: "redacted"
                                   scope: "openid profile email"
                                   claims:
@@ -82,7 +82,7 @@ data:
                                   config_endpoint: "https://accounts.google.com/.well-known/openid-configuration"
                                   upstream_cluster: "google"
                                   authority: "accounts.google.com"
-                                  redirect_uri: "https://demo.wasm-oidc-plugin.ae02.de/oidc/callback"
+                                  redirect_uri: "https://wasm-oidc-plugin.ae02.de/oidc/callback"
                                   client_id: "google-client-id"
                                   scope: "openid profile email"
                                   claims:

--- a/demo/ingress.yml
+++ b/demo/ingress.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: demo.wasm-oidc-plugin.ae02.de
+    - host: wasm-oidc-plugin.ae02.de
       http:
         paths:
           - path: /
@@ -18,5 +18,5 @@ spec:
                   number: 443
   tls:
     - hosts:
-        - demo.wasm-oidc-plugin.ae02.de
+        - wasm-oidc-plugin.ae02.de
       secretName: wasm-oidc-plugin-tls


### PR DESCRIPTION
## Summary
- Replace every `demo.wasm-oidc-plugin.ae02.de` link and example hostname with `wasm-oidc-plugin.ae02.de`.
- Leave the Auth0 tenant `demo-wasm-oidc-plugin.eu.auth0.com` unchanged.

## Test plan
- [ ] README demo-page and cookie-inspector links open `https://wasm-oidc-plugin.ae02.de`
- [ ] `demo/` Ingress/Certificate/configmap `redirect_uri` use the new host
- [ ] OIDC login on the new host still completes (Google + Auth0)


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consistently renames the live demo host from `demo.wasm-oidc-plugin.ae02.de` to `wasm-oidc-plugin.ae02.de`.
- Updates user-facing demo and cookie-inspector links.
- Aligns the Kubernetes Ingress and Certificate hostnames.
- Updates the Auth0 and Google OIDC redirect URIs while preserving the Auth0 tenant domain.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; all in-repository live-demo hostname references and dependent deployment settings are consistent.

No actionable failures were identified in the changed code or documentation. The Ingress, Certificate, redirect URIs, and public links all use the same new hostname.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Updates both public live-demo links to the new hostname. |
| demo/README.md | Updates the demo link to the new hostname. |
| demo/certificate-production.yml | Updates the certificate common name and DNS SAN consistently. |
| demo/configmap.yml | Updates both OIDC providers' callback URIs while leaving provider domains unchanged. |
| demo/ingress.yml | Updates the routing and TLS hosts consistently while retaining the matching certificate secret. |

<sub>Reviews (1): Last reviewed commit: ["Point the live demo at wasm-oidc-plugin...."](https://github.com/antonengelhardt/wasm-oidc-plugin/commit/855b5bd284c5ebfc97f92fd3a0a661ce9853fe98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60747167)</sub>

<!-- /greptile_comment -->