### PR TITLE
Drop Docker Hub image job; keep GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,32 +31,6 @@ jobs:
           name: plugin
           path: target/wasm32-wasip1/release/wasm_oidc_plugin.wasm
 
-  docker-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: antonengelhardt/wasm-oidc-plugin:latest
-          cache-from: type=registry,ref=antonengelhardt/wasm-oidc-plugin:latest
-          cache-to: type=inline
-
   ghcr-image:
     runs-on: ubuntu-latest
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,40 +29,6 @@ jobs:
           name: wasm_oidc_plugin.wasm
           path: target/wasm32-wasip1/release/wasm_oidc_plugin.wasm
 
-  docker-image:
-    name: Build and push Docker image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Extract version from Github Ref
-        id: extract_version
-        run: |
-          echo VERSION=$(echo ${{ github.ref }} | grep -o "v[0-9]\+\.[0-9]\+\.[0-9]\+") >> $GITHUB_ENV
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            antonengelhardt/wasm-oidc-plugin:${{ env.VERSION }}
-            antonengelhardt/wasm-oidc-plugin:latest
-          cache-from: type=registry,ref=antonengelhardt/wasm-oidc-plugin:latest
-          cache-to: type=inline
-
   ghcr-image:
     name: Build and push GHCR image
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,42 +161,6 @@ jobs:
           name: plugin
           path: target/wasm32-wasip1/release/wasm_oidc_plugin.wasm
 
-  docker-image:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: read
-      actions: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Sanitize branch name for image tag
-        id: image_tag
-        env:
-          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          sanitized="$(printf '%s' "$BRANCH_REF" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
-          echo "tag=pr-${sanitized}" >> "$GITHUB_OUTPUT"
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: antonengelhardt/wasm-oidc-plugin:${{ steps.image_tag.outputs.tag }}
-          cache-from: type=registry,ref=antonengelhardt/wasm-oidc-plugin:${{ steps.image_tag.outputs.tag }}
-          cache-to: type=inline
-
   ghcr-image:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Summary
- Removes the `docker-image` job from Test / Build / Release. It logged into Docker Hub with empty secrets and failed every Dependabot PR (`Username and password required`).
- GHCR push stays. That is what ae-k8s-04 pulls.

## Test plan
- [ ] Test workflow no longer has `docker-image`
- [ ] `ghcr-image` still runs on PRs and on `main`


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes Docker Hub build-and-push jobs while retaining GHCR publishing across build, release, and pull-request workflows.
- Build and release workflows continue publishing `latest` and versioned images to GHCR.
- Test workflows continue publishing branch-specific PR images to GHCR.
- Existing Docker Hub documentation references should be migrated to GHCR.

<h3>Confidence Score: 4/5</h3>

The workflow change appears safe to merge, with a non-blocking documentation cleanup needed to prevent users from following stale Docker Hub guidance.

The retained GHCR jobs preserve the repository’s active build, release, and PR image flows, and no remaining workflow dependencies reference the deleted jobs; the only identified issue is that two documentation references still direct users to the discontinued Docker Hub publication target.

**Files Needing Attention:** .github/workflows/build.yml, .github/workflows/release.yml, .github/workflows/test.yml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Removes the Docker Hub `latest` image job while retaining the build-dependent GHCR publisher. |
| .github/workflows/release.yml | Stops publishing versioned and `latest` release images to Docker Hub while preserving equivalent GHCR publication. |
| .github/workflows/test.yml | Removes Docker Hub PR-image publication while retaining repository-owned PR image publication to GHCR. |

<sub>Reviews (1): Last reviewed commit: ["Drop the Docker Hub image job; GHCR is w..."](https://github.com/antonengelhardt/wasm-oidc-plugin/commit/8cfe47e25b9acd74193e6be36bd4ce76ea504612) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60769383)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->